### PR TITLE
Permite configurar rutas vía variables de entorno y .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example configuration for Rent scripts
+# Override defaults by defining the following variables
+RENT_DIR=C:\Rentabilidad
+TEMPLATE=C:\Rentabilidad\PLANTILLA.xlsx
+EXCZDIR=D:\SIIWI01\LISTADOS
+# Optional path to an existing report
+#EXCEL=C:\Rentabilidad\INFORME_20240101.xlsx

--- a/excel_base/clone_from_template.py
+++ b/excel_base/clone_from_template.py
@@ -1,9 +1,26 @@
-import argparse, shutil
+import argparse, os, shutil
 from pathlib import Path
 from datetime import datetime
 
-DEFAULT_TEMPLATE = r"C:\\Rentabilidad\\PLANTILLA.xlsx"
-DEFAULT_OUTDIR   = r"C:\\Rentabilidad"
+
+def _load_env():
+    """Load environment variables from a .env file if present."""
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_env()
+DEFAULT_RENT_DIR = os.environ.get("RENT_DIR", r"C:\\Rentabilidad")
+DEFAULT_TEMPLATE = os.environ.get(
+    "TEMPLATE", str(Path(DEFAULT_RENT_DIR) / "PLANTILLA.xlsx")
+)
+DEFAULT_OUTDIR = os.environ.get("RENT_DIR", DEFAULT_RENT_DIR)
 
 def main():
     p = argparse.ArgumentParser(description="Clona PLANTILLA.xlsx a INFORME_YYYYMMDD.xlsx en C:\\Rentabilidad.")

--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -1,12 +1,29 @@
-import argparse, re
+import argparse, os, re
 from pathlib import Path
 from datetime import datetime
 import pandas as pd
 from openpyxl import load_workbook
 from openpyxl.utils import get_column_letter
 
-DEFAULT_EXCEL   = rf"C:\\Rentabilidad\\INFORME_{datetime.now().strftime('%Y%m%d')}.xlsx"
-DEFAULT_EXCZDIR = r"D:\\SIIWI01\\LISTADOS"
+
+def _load_env():
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_env()
+DEFAULT_RENT_DIR = os.environ.get("RENT_DIR", r"C:\\Rentabilidad")
+DEFAULT_EXCEL = os.environ.get(
+    "EXCEL",
+    str(Path(DEFAULT_RENT_DIR) / f"INFORME_{datetime.now().strftime('%Y%m%d')}.xlsx"),
+)
+DEFAULT_EXCZDIR = os.environ.get("EXCZDIR", r"D:\\SIIWI01\\LISTADOS")
 
 def _norm(s: str) -> str:
     return (str(s).strip().lower()

--- a/solo_clonar.bat
+++ b/solo_clonar.bat
@@ -1,8 +1,13 @@
 @echo off
 setlocal
-set "RENT_DIR=C:\Rentabilidad"
-set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
 set "PROJ_DIR=%~dp0"
+if exist "%PROJ_DIR%.env" (
+  for /f "usebackq tokens=1* delims==" %%a in ("%PROJ_DIR%.env") do (
+    if not "%%a"=="" set "%%a=%%b"
+  )
+)
+if not defined RENT_DIR set "RENT_DIR=C:\Rentabilidad"
+if not defined TEMPLATE set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
 
 where python >nul 2>nul || (echo ERROR: Python no esta en PATH.& pause & exit /b 9001)
 if not exist "%RENT_DIR%" mkdir "%RENT_DIR%"

--- a/solo_loader.bat
+++ b/solo_loader.bat
@@ -1,7 +1,12 @@
 @echo off
 setlocal
 set "PROJ_DIR=%~dp0"
-set "EXCZDIR=D:\SIIWI01\LISTADOS"
+if exist "%PROJ_DIR%.env" (
+  for /f "usebackq tokens=1* delims==" %%a in ("%PROJ_DIR%.env") do (
+    if not "%%a"=="" set "%%a=%%b"
+  )
+)
+if not defined EXCZDIR set "EXCZDIR=D:\SIIWI01\LISTADOS"
 
 where python >nul 2>nul || (echo ERROR: Python no esta en PATH.& pause & exit /b 9001)
 

--- a/todo_en_un_click.bat
+++ b/todo_en_un_click.bat
@@ -1,11 +1,14 @@
 @echo off
 setlocal enabledelayedexpansion
-REM ===== CONFIG =====
-set "RENT_DIR=C:\Rentabilidad"
-set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
-set "EXCZDIR=D:\SIIWI01\LISTADOS"
-REM ==================
 set "PROJ_DIR=%~dp0"
+if exist "%PROJ_DIR%.env" (
+  for /f "usebackq tokens=1* delims==" %%a in ("%PROJ_DIR%.env") do (
+    if not "%%a"=="" set "%%a=%%b"
+  )
+)
+if not defined RENT_DIR set "RENT_DIR=C:\Rentabilidad"
+if not defined TEMPLATE set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
+if not defined EXCZDIR set "EXCZDIR=D:\SIIWI01\LISTADOS"
 
 where python >nul 2>nul || (
   echo ERROR: Python no esta en PATH. Instala Python y reintenta.


### PR DESCRIPTION
## Resumen
- Agrega carga opcional de un archivo `.env` y lectura de variables de entorno en los scripts `clone_from_template.py` y `hoja01_loader.py`.
- Ajusta los `.bat` para tomar configuraciones desde variables de entorno o un `.env`, con valores por defecto.
- Incluye archivo `.env.example` como referencia de configuración.

## Testing
- `python excel_base/clone_from_template.py --help`
- `python hojas/hoja01_loader.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c58f50c2e08323b6441995a2e6290b