### PR TITLE
refactor: reuse normalization helper in hoja01_loader

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -62,14 +62,12 @@ def _read_excz_df(file: Path):
         raise ValueError("Formato no soportado: " + suffix)
 
 def _guess_map(df_cols):
-    def norm(s): 
-        return (str(s).strip().lower()
-                .replace("%","").replace(".","")
-                .replace("_"," ").replace("-"," ").replace("  "," "))
-    cols = { norm(c): c for c in df_cols }
+    cols = { _norm(c): c for c in df_cols }
     def pick(*keys):
         for k in keys:
-            if k in cols: return cols[k]
+            nk = _norm(k)
+            if nk in cols:
+                return cols[nk]
         return None
     return {
         "nit": pick("nit","nit cliente","identificacion","identificación"),


### PR DESCRIPTION
## Summary
- reuse shared `_norm` instead of duplicate local `norm` in `_guess_map`
- normalize keys via `_norm` and remove redundant function definition

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile hojas/hoja01_loader.py`
- `python hojas/hoja01_loader.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c58f49f4788323ad9b66bd16eb780d