### PR TITLE
Fix EXCZ file lookup to be case-insensitive

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -51,12 +51,12 @@ def _letter_from_header(header_map, *candidates):
     return None
 
 def _pick_latest_excz(path: Path, prefix: str):
-    pattern = rf'^{re.escape(prefix.upper())}.*\.(xlsx|xls|csv)$'
+    pattern = rf'^{re.escape(prefix.lower())}.*\.(xlsx|xls|csv)$'
     candidates = []
     for p in path.iterdir():
         if not p.is_file():
             continue
-        name = p.name.upper()
+        name = p.name.lower()
         if re.match(pattern, name):
             candidates.append(p)
     if not candidates:


### PR DESCRIPTION
## Summary
- handle EXCZ filename detection case-insensitively so latest file is found regardless of extension case

## Testing
- `python hojas/hoja01_loader.py --excel /tmp/INFORME_20230928.xlsx --exczdir /tmp/exczdir --excz-prefix EXCZ`


------
https://chatgpt.com/codex/tasks/task_e_68c592c6077483238ac6add46f1d7525