### PR TITLE
Corregir utilidad monetaria en hoja LINEAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automatiza la creación de un informe de rentabilidad a partir de una plantilla 
 ## Flujo
 
 1. **Clonado de plantilla**: `excel_base/clone_from_template.py` copia `C:\\Rentabilidad\\PLANTILLA.xlsx` a `INFORME_YYYYMMDD.xlsx`.
-2. **Carga de EXCZ**: `hojas/hoja01_loader.py` busca el archivo EXCZ con el prefijo configurado (por defecto `EXCZ980`) más reciente en `D:\\SIIWI01\\LISTADOS`, lo importa a la Hoja 1 aplicando fórmulas y, además, actualiza las hojas `CCOSTO1` a `CCOSTO4` filtrando el EXCZ `EXCZ979` por centro de costo.
+2. **Carga de EXCZ**: `hojas/hoja01_loader.py` busca el archivo EXCZ con el prefijo configurado (por defecto `EXCZ980`) más reciente en `D:\\SIIWI01\\LISTADOS`, lo importa a la Hoja 1 aplicando fórmulas y, además, actualiza las hojas `CCOSTO1` a `CCOSTO4` filtrando el EXCZ `EXCZ979` por centro de costo y la hoja `LINEAS` con los subtotales del EXCZ `EXCZ973`.
 3. **Scripts `.bat`**: automatizan el proceso:
    - `solo_clonar.bat` crea el informe a partir de la plantilla.
    - `solo_loader.bat` importa el EXCZ a un informe existente.


### PR DESCRIPTION
## Summary
- extraer los subtotales de línea y grupo desde el EXCZ973 y volcarlos en la hoja LINEAS
- añadir banderas de configuración para omitir la hoja LINEAS o ajustar el prefijo del EXCZ a usar
- documentar en el README la nueva actualización automática de la hoja LINEAS
- corregir la carga de la hoja LINEAS para calcular la utilidad monetaria a partir de las columnas de ventas y costos

## Testing
- python -m compileall hojas/hoja01_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68c88fbd202c832382708bb79da269fc