### PR TITLE
Refactorizar generación de informes con estructura modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,31 @@
 
 Automatiza la creación de un informe de rentabilidad a partir de una plantilla de Excel y la carga de datos EXCZ.
 
+## Estructura de carpetas
+
+Los scripts generan automáticamente la siguiente estructura base (todas
+las rutas son configurables mediante variables de entorno):
+
+```
+C:\Rentabilidad\
+ ├── Informes\<año>\<MM - Mes>\INFORME_YYYYMMDD.xlsx
+ └── Productos\ProductosMMDD.xlsx
+```
+
+Cada informe se almacena dentro del mes correspondiente y los listados
+de productos se guardan en la carpeta `Productos`.
+
 ## Flujo
 
-1. **Clonado de plantilla**: `excel_base/clone_from_template.py` copia `C:\\Rentabilidad\\PLANTILLA.xlsx` a `INFORME_YYYYMMDD.xlsx`.
-2. **Carga de EXCZ**: `hojas/hoja01_loader.py` busca el archivo EXCZ con el prefijo configurado (por defecto `EXCZ980`) más reciente en `D:\\SIIWI01\\LISTADOS`, lo importa a la Hoja 1 aplicando fórmulas y, además, actualiza las hojas `CCOSTO1` a `CCOSTO4` filtrando el EXCZ `EXCZ979` por centro de costo.
+1. **Clonado de plantilla**: `excel_base/clone_from_template.py` copia
+   `C:\Rentabilidad\PLANTILLA.xlsx` a la carpeta del mes
+   correspondiente generando `INFORME_YYYYMMDD.xlsx`. La fecha objetivo
+   es, por defecto, el día inmediatamente anterior.
+2. **Carga de EXCZ**: `hojas/hoja01_loader.py` identifica el archivo
+   `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincide con la solicitada (por
+   defecto el día anterior) en `D:\SIIWI01\LISTADOS`, lo importa a la
+   Hoja 1 aplicando fórmulas y actualiza las hojas `CCOSTO` y `COD` con
+   la misma fecha.
 3. **Scripts `.bat`**: automatizan el proceso:
    - `solo_clonar.bat` crea el informe a partir de la plantilla.
    - `solo_loader.bat` importa el EXCZ a un informe existente.
@@ -21,7 +42,7 @@ Automatiza la creación de un informe de rentabilidad a partir de una plantilla 
   pip install -r requirements.txt
   ```
 - Archivo `PLANTILLA.xlsx` ubicado en `C:\\Rentabilidad\\`.
-- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWI01\\LISTADOS\\`. El script busca el más reciente cuyo nombre comience con el prefijo configurado (`EXCZ980` por defecto, ajustable con `EXCZPREFIX` o `--excz-prefix`).
+- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
 
 ## Instalación
 
@@ -44,7 +65,7 @@ Automatiza la creación de un informe de rentabilidad a partir de una plantilla 
   solo_clonar.bat
   ```
 
-- Para cargar el EXCZ a un informe existente:
+- Para cargar el EXCZ a un informe existente (usa la fecha del día anterior si no se especifica `--fecha`):
 
   ```
   solo_loader.bat [ruta_a_informe.xlsx]
@@ -54,11 +75,12 @@ Cada script muestra mensajes en consola y pausa al final.
 
 ## Servicio: listado de productos desde SIIGO
 
-`servicios/generar_listado_productos.py` ejecuta el comando `ExcelSIIGO` para
-generar un Excel de productos en `C:\\Rentabilidad\\Productos` (carpeta
-configurable) y luego deja únicamente las columnas **D**, **G** a **R** y
-**AX**, filtrando además los productos cuyo campo `ACTIVO` (columna AX) sea
-`S`.
+`servicios/generar_listado_productos.py` ejecuta el comando `ExcelSIIGO`
+para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
+(carpeta configurable) y luego deja únicamente las columnas **D**, **G** a
+**R** y **AX**, filtrando además los productos cuyo campo `ACTIVO`
+(columna AX) sea `S`. El nombre resultante sigue el formato
+`ProductosMMDD.xlsx` y, por defecto, utiliza la fecha actual.
 
 - Ejecución rápida desde Windows:
 

--- a/excel_base/clone_from_template.py
+++ b/excel_base/clone_from_template.py
@@ -1,46 +1,54 @@
-import argparse, os, shutil
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
 from pathlib import Path
-from datetime import datetime
+
+from rentabilidad.core.dates import DateResolver, YesterdayStrategy
+from rentabilidad.core.env import load_env
+from rentabilidad.core.paths import PathContextFactory
 
 
-def _load_env():
-    """Load environment variables from a .env file if present."""
-    env_file = Path(__file__).resolve().parent.parent / ".env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            os.environ.setdefault(key.strip(), value.strip())
+def main() -> None:
+    load_env()
 
+    context = PathContextFactory(os.environ).create()
 
-_load_env()
-DEFAULT_RENT_DIR = os.environ.get("RENT_DIR", r"C:\\Rentabilidad")
-DEFAULT_TEMPLATE = os.environ.get(
-    "TEMPLATE", str(Path(DEFAULT_RENT_DIR) / "PLANTILLA.xlsx")
-)
-DEFAULT_OUTDIR = os.environ.get("RENT_DIR", DEFAULT_RENT_DIR)
+    parser = argparse.ArgumentParser(
+        description="Clona PLANTILLA.xlsx a INFORME_YYYYMMDD.xlsx en la estructura de C:\\Rentabilidad\\Informes."
+    )
+    parser.add_argument("--template", default=str(context.template_path()), help="Ruta a PLANTILLA.xlsx")
+    parser.add_argument(
+        "--outdir",
+        default=None,
+        help=(
+            "Carpeta de salida. Por defecto se utiliza la carpeta del mes dentro de"
+            " C\\Rentabilidad\\Informes"
+        ),
+    )
+    parser.add_argument("--fecha", default=None, help="YYYY-MM-DD (por defecto el día anterior)")
+    args = parser.parse_args()
 
-def main():
-    p = argparse.ArgumentParser(description="Clona PLANTILLA.xlsx a INFORME_YYYYMMDD.xlsx en C:\\Rentabilidad.")
-    p.add_argument("--template", default=DEFAULT_TEMPLATE, help="Ruta a PLANTILLA.xlsx")
-    p.add_argument("--outdir",   default=DEFAULT_OUTDIR,   help="Carpeta de salida")
-    p.add_argument("--fecha",    default=None,             help="YYYY-MM-DD (por defecto hoy)")
-    args = p.parse_args()
+    resolver = DateResolver(YesterdayStrategy())
+    target_date = resolver.resolve(args.fecha)
 
     template_path = Path(args.template)
     if not template_path.exists():
         print(f"ERROR: No existe {template_path}")
         raise SystemExit(2)
 
-    fecha = args.fecha or datetime.now().strftime("%Y-%m-%d")
-    yyyymmdd = fecha.replace("-", "")
-    outdir = Path(args.outdir); outdir.mkdir(parents=True, exist_ok=True)
-    out_path = outdir / f"INFORME_{yyyymmdd}.xlsx"
+    if args.outdir:
+        outdir = Path(args.outdir)
+        outdir.mkdir(parents=True, exist_ok=True)
+    else:
+        outdir = context.informe_month_dir(target_date)
+
+    out_path = outdir / f"INFORME_{target_date:%Y%m%d}.xlsx"
 
     shutil.copyfile(template_path, out_path)
     print(out_path)
+
 
 if __name__ == "__main__":
     main()

--- a/rentabilidad/__init__.py
+++ b/rentabilidad/__init__.py
@@ -1,0 +1,10 @@
+"""Paquete principal para la automatización de informes de rentabilidad."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover - mejor esfuerzo
+    __version__ = version("rent")
+except PackageNotFoundError:  # pragma: no cover - entorno editable
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/rentabilidad/core/dates.py
+++ b/rentabilidad/core/dates.py
@@ -1,0 +1,62 @@
+"""Herramientas relacionadas con el cálculo de fechas de trabajo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Protocol
+
+
+class DateStrategy(Protocol):
+    """Estrategia para obtener una fecha de referencia por defecto."""
+
+    def default(self) -> date:
+        """Retorna la fecha predeterminada."""
+
+
+class TodayStrategy:
+    """Estrategia que devuelve la fecha actual del sistema."""
+
+    def default(self) -> date:
+        return date.today()
+
+
+class YesterdayStrategy:
+    """Estrategia que devuelve la fecha del día anterior."""
+
+    def default(self) -> date:
+        return date.today() - timedelta(days=1)
+
+
+@dataclass(frozen=True)
+class DateResolver:
+    """Resuelve fechas recibidas como texto aplicando una estrategia base."""
+
+    strategy: DateStrategy
+
+    def resolve(self, value: str | None) -> date:
+        """Convierte ``value`` a ``date`` o usa la estrategia por defecto."""
+
+        if value:
+            try:
+                return datetime.strptime(value, "%Y-%m-%d").date()
+            except ValueError as exc:  # pragma: no cover - validación simple
+                raise ValueError(
+                    "La fecha debe tener el formato YYYY-MM-DD"
+                ) from exc
+        return self.strategy.default()
+
+
+def ensure_previous_day(reference: date) -> date:
+    """Devuelve el día anterior a ``reference``."""
+
+    return reference - timedelta(days=1)
+
+
+__all__ = [
+    "DateResolver",
+    "DateStrategy",
+    "TodayStrategy",
+    "YesterdayStrategy",
+    "ensure_previous_day",
+]

--- a/rentabilidad/core/env.py
+++ b/rentabilidad/core/env.py
@@ -1,0 +1,39 @@
+"""Utilidades para cargar variables de entorno desde un archivo ``.env``."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+
+@lru_cache(maxsize=1)
+def load_env(extra_paths: Iterable[Path] | None = None) -> None:
+    """Carga pares clave-valor de archivos ``.env`` hacia ``os.environ``.
+
+    Se busca un archivo ``.env`` en la raíz del repositorio (dos niveles por
+    encima de este módulo) y en las rutas adicionales proporcionadas. Los
+    valores existentes en ``os.environ`` prevalecen sobre los del archivo.
+    """
+
+    candidate_paths: list[Path] = []
+
+    base = Path(__file__).resolve().parents[2]
+    candidate_paths.append(base / ".env")
+
+    if extra_paths:
+        candidate_paths.extend(Path(p) for p in extra_paths)
+
+    for env_path in candidate_paths:
+        if not env_path.exists():
+            continue
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+
+
+__all__ = ["load_env"]

--- a/rentabilidad/core/excz.py
+++ b/rentabilidad/core/excz.py
@@ -1,0 +1,76 @@
+"""Herramientas para localizar archivos EXCZ por fecha y prefijo."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable, Protocol
+
+
+@dataclass(frozen=True)
+class ExczMetadata:
+    """Información derivada del nombre de un archivo EXCZ."""
+
+    path: Path
+    prefix: str
+    timestamp: datetime
+
+    @property
+    def date_key(self) -> str:
+        return self.timestamp.strftime("%Y%m%d")
+
+
+class ExczPattern(Protocol):
+    """Protocolo de coincidencia para nombres de archivos EXCZ."""
+
+    def match(self, name: str, prefix: str) -> datetime | None:
+        """Devuelve un ``datetime`` si ``name`` corresponde al ``prefix``."""
+
+
+class TimestampedExczPattern:
+    """Implementación que busca ``prefix`` seguido de un bloque AAAAMMDDHHMMSS."""
+
+    _regex_template = r"^{prefix}(?P<ts>\d{{14}})"
+
+    def match(self, name: str, prefix: str) -> datetime | None:
+        pattern = self._regex_template.format(prefix=re.escape(prefix.lower()))
+        match = re.match(pattern, name.lower())
+        if not match:
+            return None
+        try:
+            return datetime.strptime(match.group("ts"), "%Y%m%d%H%M%S")
+        except ValueError:
+            return None
+
+
+class ExczFileFinder:
+    """Localiza archivos EXCZ para una fecha específica."""
+
+    def __init__(self, directory: Path, pattern: ExczPattern | None = None):
+        self.directory = directory
+        self.pattern = pattern or TimestampedExczPattern()
+
+    def iter_matches(self, prefix: str) -> Iterable[ExczMetadata]:
+        if not self.directory.exists():
+            return []
+        results: list[ExczMetadata] = []
+        for child in self.directory.iterdir():
+            if not child.is_file():
+                continue
+            ts = self.pattern.match(child.name, prefix)
+            if not ts:
+                continue
+            results.append(ExczMetadata(path=child, prefix=prefix, timestamp=ts))
+        results.sort(key=lambda meta: meta.timestamp, reverse=True)
+        return results
+
+    def find_for_date(self, prefix: str, target_date: date) -> Path | None:
+        for meta in self.iter_matches(prefix):
+            if meta.timestamp.date() == target_date:
+                return meta.path
+        return None
+
+
+__all__ = ["ExczFileFinder", "ExczMetadata", "TimestampedExczPattern"]

--- a/rentabilidad/core/paths.py
+++ b/rentabilidad/core/paths.py
@@ -1,0 +1,87 @@
+"""Administración de rutas utilizadas por los procesos de rentabilidad."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Mapping
+
+SPANISH_MONTHS: Mapping[int, str] = {
+    1: "01 - Enero",
+    2: "02 - Febrero",
+    3: "03 - Marzo",
+    4: "04 - Abril",
+    5: "05 - Mayo",
+    6: "06 - Junio",
+    7: "07 - Julio",
+    8: "08 - Agosto",
+    9: "09 - Septiembre",
+    10: "10 - Octubre",
+    11: "11 - Noviembre",
+    12: "12 - Diciembre",
+}
+
+
+@dataclass(frozen=True)
+class PathContext:
+    """Representa las rutas relevantes del proceso."""
+
+    base_dir: Path
+    productos_dir: Path
+    informes_dir: Path
+
+    def ensure_structure(self) -> None:
+        """Garantiza la existencia de las carpetas base."""
+
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.productos_dir.mkdir(parents=True, exist_ok=True)
+        self.informes_dir.mkdir(parents=True, exist_ok=True)
+
+    def informe_month_dir(self, target_date: date) -> Path:
+        """Retorna la carpeta del mes para ``target_date`` dentro de Informes."""
+
+        month_name = SPANISH_MONTHS[target_date.month]
+        year_dir = self.informes_dir / str(target_date.year)
+        month_dir = year_dir / month_name
+        month_dir.mkdir(parents=True, exist_ok=True)
+        return month_dir
+
+    def informe_path(self, target_date: date) -> Path:
+        """Ruta completa al informe estándar para ``target_date``."""
+
+        month_dir = self.informe_month_dir(target_date)
+        return month_dir / f"INFORME_{target_date:%Y%m%d}.xlsx"
+
+    def productos_path(self, target_date: date) -> Path:
+        """Ruta completa al archivo de productos para ``target_date``."""
+
+        self.productos_dir.mkdir(parents=True, exist_ok=True)
+        return self.productos_dir / f"Productos{target_date:%m%d}.xlsx"
+
+    def template_path(self) -> Path:
+        """Ruta esperada de la plantilla base."""
+
+        return self.base_dir / "PLANTILLA.xlsx"
+
+
+class PathContextFactory:
+    """Fábrica que construye :class:`PathContext` a partir del entorno."""
+
+    def __init__(self, environ: Mapping[str, str]):
+        self._environ = environ
+
+    def create(self) -> PathContext:
+        base_dir = Path(self._environ.get("RENT_DIR", r"C:\\Rentabilidad"))
+        productos_dir = Path(
+            self._environ.get("PRODUCTOS_DIR", str(base_dir / "Productos"))
+        )
+        informes_dir = Path(
+            self._environ.get("INFORMES_DIR", str(base_dir / "Informes"))
+        )
+        context = PathContext(base_dir=base_dir, productos_dir=productos_dir, informes_dir=informes_dir)
+        context.ensure_structure()
+        return context
+
+
+__all__ = ["PathContext", "PathContextFactory", "SPANISH_MONTHS"]

--- a/rentabilidad/services/products.py
+++ b/rentabilidad/services/products.py
@@ -1,0 +1,178 @@
+"""Servicios para la generación y depuración del listado de productos."""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from openpyxl import load_workbook
+from openpyxl.utils import column_index_from_string
+
+from rentabilidad.core.paths import PathContext
+
+
+@dataclass
+class SiigoCredentials:
+    """Agrupa los parámetros de autenticación para ExcelSIIGO."""
+
+    reporte: str
+    empresa: str
+    usuario: str
+    clave: str
+    estado_param: str
+    rango_ini: str
+    rango_fin: str
+
+
+@dataclass
+class ProductGenerationConfig:
+    """Configuración necesaria para generar el archivo de productos."""
+
+    siigo_dir: Path
+    base_path: str
+    log_path: str
+    credentials: SiigoCredentials
+    activo_column: str
+    keep_columns: Sequence[int]
+
+
+class ExcelSiigoFacade:
+    """Fachada que ejecuta ExcelSIIGO y gestiona los parámetros requeridos."""
+
+    def __init__(self, config: ProductGenerationConfig):
+        self._config = config
+
+    def run(self, output_path: Path, year: str) -> None:
+        command = [
+            "ExcelSIIGO",
+            self._config.base_path,
+            year,
+            self._config.credentials.reporte,
+            self._config.credentials.empresa,
+            self._config.credentials.usuario,
+            self._config.credentials.clave,
+            self._config.log_path,
+            self._config.credentials.estado_param,
+            self._config.credentials.rango_ini,
+            self._config.credentials.rango_fin,
+            str(output_path),
+        ]
+
+        result = subprocess.run(
+            command,
+            cwd=str(self._config.siigo_dir),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.stdout:
+            print(result.stdout.strip())
+        if result.stderr:
+            print(result.stderr.strip())
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                "ExcelSIIGO falló con código "
+                f"{result.returncode}: {result.stderr.strip() or result.stdout.strip()}"
+            )
+
+
+class WorkbookCleaner:
+    """Responsable de filtrar columnas y filas en el archivo generado."""
+
+    def __init__(self, activo_column: str, keep_columns: Iterable[int]):
+        self._activo_idx = column_index_from_string(activo_column)
+        self._keep_columns = {int(idx) for idx in keep_columns}
+        self._keep_columns.add(self._activo_idx)
+
+    def clean(self, file_path: Path) -> None:
+        wb = load_workbook(filename=file_path)
+        ws = wb.active
+
+        if ws.max_column < self._activo_idx:
+            raise RuntimeError(
+                "La hoja activa no tiene la columna requerida para estado del producto."
+            )
+
+        for row in range(ws.max_row, 1, -1):
+            value = ws.cell(row=row, column=self._activo_idx).value
+            if self._normalize(value) != "S":
+                ws.delete_rows(row, 1)
+
+        for col in range(ws.max_column, 0, -1):
+            if col not in self._keep_columns:
+                ws.delete_cols(col, 1)
+
+        wb.save(file_path)
+
+    @staticmethod
+    def _normalize(value) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip().upper()
+        return str(value).strip().upper()
+
+
+@contextmanager
+def safe_backup(path: Path):
+    """Crea un ``.bak`` temporal y lo restaura si ocurre un error."""
+
+    backup = None
+    if path.exists():
+        backup = path.with_suffix(path.suffix + ".bak")
+        if backup.exists():
+            backup.unlink()
+        path.replace(backup)
+    try:
+        yield
+    except Exception:
+        if backup and backup.exists():
+            if path.exists():
+                path.unlink()
+            backup.replace(path)
+        raise
+    else:
+        if backup and backup.exists():
+            backup.unlink()
+
+
+class ProductListingService:
+    """Servicio principal para crear y depurar el archivo de productos."""
+
+    def __init__(
+        self,
+        context: PathContext,
+        config: ProductGenerationConfig,
+    ):
+        self._context = context
+        self._config = config
+        self._facade = ExcelSiigoFacade(config)
+        self._cleaner = WorkbookCleaner(
+            activo_column=config.activo_column, keep_columns=config.keep_columns
+        )
+
+    def generate(self, target_date: date) -> Path:
+        output_path = self._context.productos_path(target_date)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        print(f"INFO: Ejecutando ExcelSIIGO para generar {output_path}")
+        with safe_backup(output_path):
+            self._facade.run(output_path, target_date.strftime("%Y"))
+            print("INFO: Limpiando el archivo generado...")
+            self._cleaner.clean(output_path)
+        print(f"OK: Archivo final listo en {output_path}")
+        return output_path
+
+
+__all__ = [
+    "ProductGenerationConfig",
+    "ProductListingService",
+    "SiigoCredentials",
+    "WorkbookCleaner",
+]

--- a/servicios/generar_listado_productos.py
+++ b/servicios/generar_listado_productos.py
@@ -1,273 +1,141 @@
+from __future__ import annotations
+
 import argparse
 import os
-import subprocess
-from datetime import datetime
 from pathlib import Path
-from typing import Iterable
 
-from openpyxl import load_workbook
 from openpyxl.utils import column_index_from_string
 
-
-def _load_env() -> None:
-    """Load environment variables from a .env file if present."""
-    env_file = Path(__file__).resolve().parent.parent / ".env"
-    if env_file.exists():
-        for line in env_file.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            os.environ.setdefault(key.strip(), value.strip())
-
-
-_load_env()
-
-DEFAULT_SIIGO_DIR = os.environ.get("SIIGO_DIR", r"C:\\Siigo")
-DEFAULT_SIIGO_BASE = os.environ.get("SIIGO_BASE", r"D:\\SIIWI01")
-DEFAULT_LOG_PATH = os.environ.get(
-    "SIIGO_LOG", str(Path(DEFAULT_SIIGO_BASE) / "LOGS" / "log_catalogos.txt")
+from rentabilidad.core.env import load_env
+from rentabilidad.core.dates import DateResolver, TodayStrategy
+from rentabilidad.core.paths import PathContext, PathContextFactory
+from rentabilidad.services.products import (
+    ProductGenerationConfig,
+    ProductListingService,
+    SiigoCredentials,
 )
-DEFAULT_PRODUCTOS_DIR = os.environ.get(
-    "PRODUCTOS_DIR", r"C:\\Rentabilidad\\Productos"
-)
-DEFAULT_REPORTE = os.environ.get("SIIGO_REPORTE", "GETINV")
-DEFAULT_EMPRESA = os.environ.get("SIIGO_EMPRESA", "L")
-DEFAULT_USUARIO = os.environ.get("SIIGO_USUARIO", "JUAN")
-DEFAULT_CLAVE = os.environ.get("SIIGO_CLAVE", "0110")
-DEFAULT_ESTADO_PARAM = os.environ.get("SIIGO_ESTADO_PARAM", "S")
-DEFAULT_RANGO_INI = os.environ.get("SIIGO_RANGO_INI", "0010001000001")
-DEFAULT_RANGO_FIN = os.environ.get("SIIGO_RANGO_FIN", "0400027999999")
-DEFAULT_ACTIVO_COL = os.environ.get("SIIGO_ACTIVO_COL", "AX")
-KEEP_COLUMN_NUMBERS = {4, *range(7, 19)}
-KEEP_COLUMN_NUMBERS.add(column_index_from_string(DEFAULT_ACTIVO_COL))
+
+KEEP_COLUMN_NUMBERS = (4, *range(7, 19))
 
 
 def _ensure_trailing_backslash(path: str) -> str:
-    if path.endswith(("\\", "/")):
-        return path
-    return path + "\\"
+    return path if path.endswith(("\\", "/")) else path + "\\"
 
 
-def _build_output_path(productos_dir: Path, fecha: datetime) -> Path:
-    productos_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"Productos{fecha.strftime('%m')}{fecha.strftime('%d')}.xlsx"
-    return productos_dir / filename
-
-
-def _run_excel_siigo(
-    *,
-    siigo_dir: Path,
-    base_path: str,
-    ano: str,
-    reporte: str,
-    empresa: str,
-    usuario: str,
-    clave: str,
-    log_path: str,
-    estado_param: str,
-    rango_ini: str,
-    rango_fin: str,
-    output_path: Path,
-) -> None:
-    command = [
-        "ExcelSIIGO",
-        base_path,
-        ano,
-        reporte,
-        empresa,
-        usuario,
-        clave,
-        log_path,
-        estado_param,
-        rango_ini,
-        rango_fin,
-        str(output_path),
-    ]
-
-    result = subprocess.run(
-        command,
-        cwd=str(siigo_dir),
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    if result.stdout:
-        print(result.stdout.strip())
-    if result.stderr:
-        print(result.stderr.strip())
-
-    if result.returncode != 0:
-        raise RuntimeError(
-            "ExcelSIIGO fallo con codigo "
-            f"{result.returncode}: {result.stderr.strip() or result.stdout.strip()}"
-        )
-
-
-def _normalize_activo(value) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value.strip().upper()
-    return str(value).strip().upper()
-
-
-def _clean_excel(
-    file_path: Path,
-    *,
-    activo_column: str,
-    keep_columns: Iterable[int],
-) -> None:
-    wb = load_workbook(filename=file_path)
-    ws = wb.active
-
-    activo_idx = column_index_from_string(activo_column)
-    if ws.max_column < activo_idx:
-        raise RuntimeError(
-            f"La hoja activa no tiene la columna {activo_column} (indice {activo_idx})."
-        )
-
-    for row in range(ws.max_row, 1, -1):
-        value = ws.cell(row=row, column=activo_idx).value
-        if _normalize_activo(value) != "S":
-            ws.delete_rows(row, 1)
-
-    keep_set = set(keep_columns)
-    # Ensure the activo column stays even if it was not part of the defaults
-    keep_set.add(activo_idx)
-
-    max_col = ws.max_column
-    for col in range(max_col, 0, -1):
-        if col not in keep_set:
-            ws.delete_cols(col, 1)
-
-    wb.save(file_path)
-
-
-def main() -> None:
+def build_parser(defaults: dict[str, str]) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Ejecuta ExcelSIIGO para generar el listado de productos y "
-            "depura el archivo dejando solo columnas relevantes y "
-            "productos activos."
+            "Ejecuta ExcelSIIGO para generar el listado de productos, "
+            "depura el archivo dejando solo columnas relevantes y productos activos."
         )
     )
-    parser.add_argument("--siigo-dir", default=DEFAULT_SIIGO_DIR, help="Carpeta donde se ubica ExcelSIIGO.exe")
+    parser.add_argument("--siigo-dir", default=defaults["SIIGO_DIR"], help="Carpeta donde se ubica ExcelSIIGO.exe")
     parser.add_argument(
         "--siigo-base",
-        default=DEFAULT_SIIGO_BASE,
+        default=defaults["SIIGO_BASE"],
         help="Ruta base usada como primer argumento para ExcelSIIGO (ej. D:\\SIIWI01)",
     )
     parser.add_argument(
         "--productos-dir",
-        default=DEFAULT_PRODUCTOS_DIR,
-        help="Carpeta destino donde se guardara el listado de productos",
+        default=defaults["PRODUCTOS_DIR"],
+        help="Carpeta destino donde se guardará el listado de productos",
     )
     parser.add_argument(
         "--log",
-        default=DEFAULT_LOG_PATH,
-        help="Ruta del archivo de log que usara ExcelSIIGO",
+        default=defaults["SIIGO_LOG"],
+        help="Ruta del archivo de log que usará ExcelSIIGO",
     )
     parser.add_argument("--fecha", help="Fecha a usar en formato YYYY-MM-DD (por defecto hoy)")
-    parser.add_argument("--reporte", default=DEFAULT_REPORTE, help="Codigo de reporte a solicitar (GETINV por defecto)")
-    parser.add_argument("--empresa", default=DEFAULT_EMPRESA, help="Codigo de empresa para ExcelSIIGO")
-    parser.add_argument("--usuario", default=DEFAULT_USUARIO, help="Usuario para ExcelSIIGO")
-    parser.add_argument("--clave", default=DEFAULT_CLAVE, help="Clave de ExcelSIIGO")
+    parser.add_argument("--reporte", default=defaults["SIIGO_REPORTE"], help="Código de reporte a solicitar (GETINV por defecto)")
+    parser.add_argument("--empresa", default=defaults["SIIGO_EMPRESA"], help="Código de empresa para ExcelSIIGO")
+    parser.add_argument("--usuario", default=defaults["SIIGO_USUARIO"], help="Usuario para ExcelSIIGO")
+    parser.add_argument("--clave", default=defaults["SIIGO_CLAVE"], help="Clave de ExcelSIIGO")
     parser.add_argument(
         "--estado-param",
-        default=DEFAULT_ESTADO_PARAM,
-        help="Parametro de estado para ExcelSIIGO (S por defecto)",
+        default=defaults["SIIGO_ESTADO_PARAM"],
+        help="Parámetro de estado para ExcelSIIGO (S por defecto)",
     )
     parser.add_argument(
         "--rango-inicial",
-        default=DEFAULT_RANGO_INI,
-        help="Codigo inicial de rango de productos",
+        default=defaults["SIIGO_RANGO_INI"],
+        help="Código inicial de rango de productos",
     )
     parser.add_argument(
         "--rango-final",
-        default=DEFAULT_RANGO_FIN,
-        help="Codigo final de rango de productos",
+        default=defaults["SIIGO_RANGO_FIN"],
+        help="Código final de rango de productos",
     )
     parser.add_argument(
         "--activo-column",
-        default=DEFAULT_ACTIVO_COL,
-        help="Columna (por letra) que indica si el producto esta activo",
+        default=defaults["SIIGO_ACTIVO_COL"],
+        help="Columna (por letra) que indica si el producto está activo",
     )
+    return parser
 
+
+def _collect_defaults() -> dict[str, str]:
+    context = PathContextFactory(os.environ).create()
+    defaults = {
+        "SIIGO_DIR": os.environ.get("SIIGO_DIR", r"C:\\Siigo"),
+        "SIIGO_BASE": os.environ.get("SIIGO_BASE", r"D:\\SIIWI01"),
+        "SIIGO_LOG": os.environ.get("SIIGO_LOG", str(Path(os.environ.get("SIIGO_BASE", r"D:\\SIIWI01")) / "LOGS" / "log_catalogos.txt")),
+        "SIIGO_REPORTE": os.environ.get("SIIGO_REPORTE", "GETINV"),
+        "SIIGO_EMPRESA": os.environ.get("SIIGO_EMPRESA", "L"),
+        "SIIGO_USUARIO": os.environ.get("SIIGO_USUARIO", "JUAN"),
+        "SIIGO_CLAVE": os.environ.get("SIIGO_CLAVE", "0110"),
+        "SIIGO_ESTADO_PARAM": os.environ.get("SIIGO_ESTADO_PARAM", "S"),
+        "SIIGO_RANGO_INI": os.environ.get("SIIGO_RANGO_INI", "0010001000001"),
+        "SIIGO_RANGO_FIN": os.environ.get("SIIGO_RANGO_FIN", "0400027999999"),
+        "SIIGO_ACTIVO_COL": os.environ.get("SIIGO_ACTIVO_COL", "AX"),
+        "PRODUCTOS_DIR": os.environ.get("PRODUCTOS_DIR", str(context.productos_dir)),
+    }
+    return defaults
+
+
+def main() -> None:
+    load_env()
+    defaults = _collect_defaults()
+    parser = build_parser(defaults)
     args = parser.parse_args()
 
-    try:
-        siigo_dir = Path(args.siigo_dir)
-        if not siigo_dir.exists():
-            raise RuntimeError(f"No existe la carpeta de SIIGO: {siigo_dir}")
+    resolver = DateResolver(TodayStrategy())
+    fecha = resolver.resolve(args.fecha)
 
-        fecha = (
-            datetime.strptime(args.fecha, "%Y-%m-%d")
-            if args.fecha
-            else datetime.now()
+    context = PathContextFactory(os.environ).create()
+    if args.productos_dir:
+        context = PathContext(
+            base_dir=context.base_dir,
+            productos_dir=Path(args.productos_dir),
+            informes_dir=context.informes_dir,
         )
-        ano = fecha.strftime("%Y")
-        productos_dir = Path(args.productos_dir)
-        output_path = _build_output_path(productos_dir, fecha)
+        context.ensure_structure()
 
-        base_path = _ensure_trailing_backslash(args.siigo_base)
+    siigo_dir = Path(args.siigo_dir)
+    if not siigo_dir.exists():
+        raise SystemExit(f"No existe la carpeta de SIIGO: {siigo_dir}")
 
-        log_path = args.log
-        if not log_path:
-            log_path = str(Path(base_path) / "LOGS" / "log_catalogos.txt")
+    credenciales = SiigoCredentials(
+        reporte=args.reporte,
+        empresa=args.empresa,
+        usuario=args.usuario,
+        clave=args.clave,
+        estado_param=args.estado_param,
+        rango_ini=args.rango_inicial,
+        rango_fin=args.rango_final,
+    )
 
-        backup_path = None
-        if output_path.exists():
-            backup_path = output_path.with_suffix(output_path.suffix + ".bak")
-            try:
-                if backup_path.exists():
-                    backup_path.unlink()
-                output_path.rename(backup_path)
-            except OSError as exc:
-                raise RuntimeError(
-                    f"No se pudo respaldar el archivo existente {output_path}: {exc}"
-                ) from exc
+    config = ProductGenerationConfig(
+        siigo_dir=siigo_dir,
+        base_path=_ensure_trailing_backslash(args.siigo_base),
+        log_path=args.log,
+        credentials=credenciales,
+        activo_column=args.activo_column,
+        keep_columns=KEEP_COLUMN_NUMBERS + (column_index_from_string(args.activo_column),),
+    )
 
-        try:
-            print(f"INFO: Ejecutando ExcelSIIGO para generar {output_path}")
-            _run_excel_siigo(
-                siigo_dir=siigo_dir,
-                base_path=base_path,
-                ano=ano,
-                reporte=args.reporte,
-                empresa=args.empresa,
-                usuario=args.usuario,
-                clave=args.clave,
-                log_path=log_path,
-                estado_param=args.estado_param,
-                rango_ini=args.rango_inicial,
-                rango_fin=args.rango_final,
-                output_path=output_path,
-            )
-
-            print("INFO: Limpiando el archivo generado...")
-            _clean_excel(
-                output_path,
-                activo_column=args.activo_column,
-                keep_columns=KEEP_COLUMN_NUMBERS,
-            )
-            print(f"OK: Archivo final listo en {output_path}")
-        except Exception:
-            if backup_path and backup_path.exists():
-                try:
-                    if output_path.exists():
-                        output_path.unlink()
-                except OSError:
-                    pass
-                try:
-                    backup_path.rename(output_path)
-                except OSError:
-                    pass
-            raise
-        else:
-            if backup_path and backup_path.exists():
-                backup_path.unlink()
+    service = ProductListingService(context, config)
+    try:
+        service.generate(fecha)
     except Exception as exc:  # noqa: BLE001 - queremos mostrar cualquier error amigablemente
         raise SystemExit(str(exc))
 


### PR DESCRIPTION
## Summary
- crear el paquete `rentabilidad` con utilidades compartidas para fechas, rutas, lectura de EXCZ y servicios de productos
- refactorizar los scripts de productos, clonación de plantillas y carga de informes para usar la nueva arquitectura y manejar fechas del día anterior
- actualizar la documentación para describir la nueva estructura de carpetas y el flujo de trabajo

## Testing
- python -m compileall rentabilidad servicios excel_base hojas

------
https://chatgpt.com/codex/tasks/task_e_68cc665198d4832392ca7a7fdd0fad10