### PR TITLE
Add compatibility shim for legacy yesterday imports

### DIFF
--- a/Yesterday.py
+++ b/Yesterday.py
@@ -1,0 +1,17 @@
+"""Compatibilidad para proyectos que importaban ``Yesterday`` con mayúscula."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+from yesterday import DateResolver, YesterdayStrategy
+
+__all__ = ["DateResolver", "YesterdayStrategy"]
+
+# Exponer el submódulo legado ``Yesterday.get_date`` reutilizando la versión
+# definida en ``yesterday``.
+sys.modules[__name__ + ".get_date"] = importlib.import_module("yesterday.get_date")
+
+# Garantizar que ambos nombres remiten al mismo objeto de módulo.
+sys.modules.setdefault("yesterday", sys.modules[__name__])

--- a/yesterday/__init__.py
+++ b/yesterday/__init__.py
@@ -1,0 +1,32 @@
+"""Compatibilidad con importaciones antiguas de ``yesterday``.
+
+Este paquete mantiene la API original expuesta por ``yesterday`` para que el
+código legado continúe funcionando. Los componentes reales ahora viven en
+:mod:`rentabilidad.core.dates`.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from rentabilidad.core.dates import DateResolver, YesterdayStrategy
+
+__all__ = ["DateResolver", "YesterdayStrategy"]
+
+
+def _register_submodule() -> None:
+    """Crea el submódulo ``yesterday.get_date`` para compatibilidad."""
+
+    module_name = __name__ + ".get_date"
+    if module_name in sys.modules:
+        return
+
+    shim = ModuleType(module_name)
+    shim.DateResolver = DateResolver
+    shim.YesterdayStrategy = YesterdayStrategy
+    shim.__all__ = ["DateResolver", "YesterdayStrategy"]
+    sys.modules[module_name] = shim
+
+
+_register_submodule()

--- a/yesterday/get_date.py
+++ b/yesterday/get_date.py
@@ -1,0 +1,5 @@
+"""Punto de entrada legacy para ``from yesterday.get_date import ...``."""
+
+from rentabilidad.core.dates import DateResolver, YesterdayStrategy
+
+__all__ = ["DateResolver", "YesterdayStrategy"]


### PR DESCRIPTION
## Summary
- add a legacy-compatible `yesterday` package that proxies to `rentabilidad.core.dates`
- expose a `Yesterday` module alias so historic imports continue to function

## Testing
- python -m compileall yesterday Yesterday.py

------
https://chatgpt.com/codex/tasks/task_e_68cc768d670c83238fd5a7095098f2a3