### PR TITLE
Alinear nombres de informes y exportaciones de productos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ las rutas son configurables mediante variables de entorno):
 
 ```
 C:\Rentabilidad\
- ├── Informes\<año>\<MM - Mes>\INFORME_YYYYMMDD.xlsx
- └── Productos\ProductosMMDD.xlsx
+ ├── Informes\<Mes>\<Mes> DD.xlsx
+ └── Productos\productosMMDD.xlsx
 ```
 
 Cada informe se almacena dentro del mes correspondiente y los listados
@@ -20,7 +20,7 @@ de productos se guardan en la carpeta `Productos`.
 
 1. **Clonado de plantilla**: `excel_base/clone_from_template.py` copia
    `C:\Rentabilidad\PLANTILLA.xlsx` a la carpeta del mes
-   correspondiente generando `INFORME_YYYYMMDD.xlsx`. La fecha objetivo
+   correspondiente generando `<Mes> DD.xlsx`. La fecha objetivo
    es, por defecto, el día inmediatamente anterior.
 2. **Carga de EXCZ**: `hojas/hoja01_loader.py` identifica el archivo
    `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincide con la solicitada (por
@@ -80,7 +80,7 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
 (carpeta configurable) y luego deja únicamente las columnas **D**, **G** a
 **R** y **AX**, filtrando además los productos cuyo campo `ACTIVO`
 (columna AX) sea `S`. El nombre resultante sigue el formato
-`ProductosMMDD.xlsx` y, por defecto, utiliza la fecha actual.
+`productosMMDD.xlsx` y, por defecto, utiliza la fecha actual.
 
 - Ejecución rápida desde Windows:
 
@@ -97,5 +97,5 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
   - `SIIGO_LOG`: ruta del archivo de log usado por `ExcelSIIGO`
     (por defecto `D:\\SIIWI01\\LOGS\\log_catalogos.txt`).
 
-El archivo resultante sigue el formato `ProductosMMDD.xlsx`, usando la fecha
+El archivo resultante sigue el formato `productosMMDD.xlsx`, usando la fecha
 actual si no se indica otra con la opción `--fecha`.

--- a/excel_base/clone_from_template.py
+++ b/excel_base/clone_from_template.py
@@ -16,7 +16,10 @@ def main() -> None:
     context = PathContextFactory(os.environ).create()
 
     parser = argparse.ArgumentParser(
-        description="Clona PLANTILLA.xlsx a INFORME_YYYYMMDD.xlsx en la estructura de C:\\Rentabilidad\\Informes."
+        description=(
+            "Clona PLANTILLA.xlsx a '<Mes> DD.xlsx' dentro de la estructura de "
+            r"C:\Rentabilidad\Informes."
+        )
     )
     parser.add_argument("--template", default=str(context.template_path()), help="Ruta a PLANTILLA.xlsx")
     parser.add_argument(
@@ -24,7 +27,7 @@ def main() -> None:
         default=None,
         help=(
             "Carpeta de salida. Por defecto se utiliza la carpeta del mes dentro de"
-            " C\\Rentabilidad\\Informes"
+            r" C:\Rentabilidad\Informes"
         ),
     )
     parser.add_argument("--fecha", default=None, help="YYYY-MM-DD (por defecto el día anterior)")
@@ -44,7 +47,7 @@ def main() -> None:
     else:
         outdir = context.informe_month_dir(target_date)
 
-    out_path = outdir / f"INFORME_{target_date:%Y%m%d}.xlsx"
+    out_path = outdir / context.informe_filename(target_date)
 
     shutil.copyfile(template_path, out_path)
     print(out_path)

--- a/rentabilidad/core/paths.py
+++ b/rentabilidad/core/paths.py
@@ -8,18 +8,18 @@ from pathlib import Path
 from typing import Mapping
 
 SPANISH_MONTHS: Mapping[int, str] = {
-    1: "01 - Enero",
-    2: "02 - Febrero",
-    3: "03 - Marzo",
-    4: "04 - Abril",
-    5: "05 - Mayo",
-    6: "06 - Junio",
-    7: "07 - Julio",
-    8: "08 - Agosto",
-    9: "09 - Septiembre",
-    10: "10 - Octubre",
-    11: "11 - Noviembre",
-    12: "12 - Diciembre",
+    1: "Enero",
+    2: "Febrero",
+    3: "Marzo",
+    4: "Abril",
+    5: "Mayo",
+    6: "Junio",
+    7: "Julio",
+    8: "Agosto",
+    9: "Septiembre",
+    10: "Octubre",
+    11: "Noviembre",
+    12: "Diciembre",
 }
 
 
@@ -42,8 +42,7 @@ class PathContext:
         """Retorna la carpeta del mes para ``target_date`` dentro de Informes."""
 
         month_name = SPANISH_MONTHS[target_date.month]
-        year_dir = self.informes_dir / str(target_date.year)
-        month_dir = year_dir / month_name
+        month_dir = self.informes_dir / month_name
         month_dir.mkdir(parents=True, exist_ok=True)
         return month_dir
 
@@ -51,13 +50,19 @@ class PathContext:
         """Ruta completa al informe estándar para ``target_date``."""
 
         month_dir = self.informe_month_dir(target_date)
-        return month_dir / f"INFORME_{target_date:%Y%m%d}.xlsx"
+        return month_dir / self.informe_filename(target_date)
+
+    def informe_filename(self, target_date: date) -> str:
+        """Nombre del archivo de informe para ``target_date``."""
+
+        month_name = SPANISH_MONTHS[target_date.month]
+        return f"{month_name} {target_date:%d}.xlsx"
 
     def productos_path(self, target_date: date) -> Path:
         """Ruta completa al archivo de productos para ``target_date``."""
 
         self.productos_dir.mkdir(parents=True, exist_ok=True)
-        return self.productos_dir / f"Productos{target_date:%m%d}.xlsx"
+        return self.productos_dir / f"productos{target_date:%m%d}.xlsx"
 
     def template_path(self) -> Path:
         """Ruta esperada de la plantilla base."""


### PR DESCRIPTION
## Summary
- actualizar PathContext para que los informes usen carpetas por mes con archivos `<Mes> DD.xlsx` y los listados de productos `productosMMDD.xlsx`
- ajustar hoja01_loader para detectar los nuevos nombres, modificar los textos de ayuda y usar el prefijo `productos` por defecto
- actualizar el script de clonado y la documentación para reflejar la nueva estructura de carpetas

## Testing
- python -m compileall rentabilidad excel_base servicios/generar_listado_productos.py hojas/hoja01_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7d59be808323b57a4f451084e3de