### PR TITLE
Fix clone script to import rentabilidad package correctly

### DIFF
--- a/excel_base/clone_from_template.py
+++ b/excel_base/clone_from_template.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import sys
 from pathlib import Path
+
+
+CURRENT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CURRENT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 
 from rentabilidad.core.dates import DateResolver, YesterdayStrategy
 from rentabilidad.core.env import load_env


### PR DESCRIPTION
## Summary
- ensure the excel cloning script adjusts sys.path to include the repository root so rentabilidad imports succeed when executed directly

## Testing
- python -m compileall excel_base/clone_from_template.py

------
https://chatgpt.com/codex/tasks/task_e_68cc824c25b083238a22c80fd2e4a24c