### PR TITLE
Fix discount formatting and informe output directory

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -1306,6 +1306,7 @@ def main():
             c = ws[f"{L_desc}{r}"]
             c.value = f"=1-(({L_vent}{r}*1.19)/{L_cant}{r}/{L_prec}{r})"
             c.border = border
+            c.number_format = "0.00%"
 
     # --- Fila de Total General -------------------------------------------
     total_label = "Total General"

--- a/todo_en_un_click.bat
+++ b/todo_en_un_click.bat
@@ -31,7 +31,7 @@ if exist "%PROJ_DIR%requirements.txt" (
 )
 
 for /f "usebackq delims=" %%F in (`
-  python "%PROJ_DIR%excel_base\clone_from_template.py" --template "%TEMPLATE%" --outdir "%RENT_DIR%"
+  python "%PROJ_DIR%excel_base\clone_from_template.py" --template "%TEMPLATE%"
 `) do set "INFORME=%%F"
 
 if not defined INFORME (


### PR DESCRIPTION
## Summary
- ensure the descuento formula writes values with percentage formatting
- rely on the default informes directory when cloning the template so the report is saved under the monthly folder

## Testing
- python -m compileall hojas/hoja01_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb6553f488323a5af822c5270732d