### PR TITLE
Add GUI interface and improve data selection

### DIFF
--- a/rentabilidad/core/excz.py
+++ b/rentabilidad/core/excz.py
@@ -21,6 +21,15 @@ class ExczMetadata:
     def date_key(self) -> str:
         return self.timestamp.strftime("%Y%m%d")
 
+    @property
+    def modified_at(self) -> float:
+        """Marca de tiempo de última modificación en segundos."""
+
+        try:
+            return self.path.stat().st_mtime
+        except FileNotFoundError:
+            return 0.0
+
 
 class ExczPattern(Protocol):
     """Protocolo de coincidencia para nombres de archivos EXCZ."""
@@ -71,6 +80,15 @@ class ExczFileFinder:
             if meta.timestamp.date() == target_date:
                 return meta.path
         return None
+
+    def find_latest(self, prefix: str) -> Path | None:
+        """Devuelve el archivo más reciente según fecha de modificación."""
+
+        matches = list(self.iter_matches(prefix))
+        if not matches:
+            return None
+        latest = max(matches, key=lambda meta: meta.modified_at)
+        return latest.path
 
 
 __all__ = ["ExczFileFinder", "ExczMetadata", "TimestampedExczPattern"]

--- a/rentabilidad/gui/__init__.py
+++ b/rentabilidad/gui/__init__.py
@@ -1,0 +1,5 @@
+"""Interfaz gráfica para ejecutar los procesos de rentabilidad."""
+
+from .app import RentApp, main
+
+__all__ = ["RentApp", "main"]

--- a/rentabilidad/gui/__main__.py
+++ b/rentabilidad/gui/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .app import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add a Tkinter-based panel that orchestrates report generation, product listings, and live logging for the rentabilidad workflows
- allow hoja01_loader to pick the most recent EXCZ, vendedores, and precios files via a new --use-latest-sources flag and supporting helpers
- expose modification times in ExczMetadata to support latest-file lookups

## Testing
- python -m compileall rentabilidad hojas servicios
- python hojas/hoja01_loader.py --help | head

------
https://chatgpt.com/codex/tasks/task_e_68cdcf155bb88323b512e01e64cf99ff