### PR TITLE
Add default .env configuration for batch scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Personal configuration for Rent scripts
+# Customize the paths below to match your environment.
+RENT_DIR=C:\Rentabilidad
+TEMPLATE=C:\Rentabilidad\PLANTILLA.xlsx
+EXCZDIR=D:\SIIWI01\LISTADOS
+EXCZPREFIX=EXCZ980
+# Optional: point to an existing report if you only need to correr el loader
+#EXCEL=C:\Rentabilidad\INFORME_20240101.xlsx


### PR DESCRIPTION
## Summary
- add a committed .env file with the default Rent, template and EXCZ paths
- document optional EXCEL override within the .env for loader-only runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdfd17e65883239dce326a551b4449