### PR TITLE
Corrige proporciones de la plantilla en la pestaña de informes

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -732,10 +732,10 @@ class RentApp(tk.Tk):
             style="Code.TLabel",
         ).grid(row=0, column=0, sticky="w")
 
-        parent.rowconfigure(1, weight=1)
+        parent.rowconfigure(2, weight=1)
 
         cards_frame = ttk.Frame(parent, style="Tab.TFrame")
-        cards_frame.grid(row=1, column=0, sticky="nsew", pady=(12, 0))
+        cards_frame.grid(row=2, column=0, sticky="nsew", pady=(12, 0))
         cards_frame.columnconfigure(0, weight=1, uniform="report")
         cards_frame.columnconfigure(1, weight=1, uniform="report")
         cards_frame.rowconfigure(0, weight=1)


### PR DESCRIPTION
## Resumen
- Ajusta la fila usada por el bloque "Plantilla base" para que conserve la altura mínima.
- Mueve el contenedor principal de tarjetas a una fila independiente que puede expandirse sin afectar al resto de la vista.

## Pruebas
- python -m compileall rentabilidad/gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68cec2e5503c8323aa36ee72d3c1ebf8