### PR TITLE
Update NiceGUI readonly usage to props chaining

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -60,7 +60,8 @@ with ui.column().classes("max-w-5xl mx-auto py-6 gap-6"):
 
         with ui.row().classes('items-center gap-2 w-full'):
             ruta_input = (
-                ui.input(value=str(settings.ruta_plantilla), readonly=True)
+                ui.input(value=str(settings.ruta_plantilla))
+                .props('readonly')
                 .classes('flex-1 bg-gray-50 rounded-xl p-2 h-10 min-h-0 text-sm')
             )
             ui.button(

--- a/rentabilidad/gui/web.py
+++ b/rentabilidad/gui/web.py
@@ -116,7 +116,8 @@ def setup_ui() -> None:
                 ui.label("Plantilla base").classes("font-medium")
 
             with ui.row().classes("items-center gap-2 w-full"):
-                ui.input(value=RUTA_PLANTILLA, readonly=True) \
+                ui.input(value=RUTA_PLANTILLA) \
+                    .props("readonly") \
                     .classes("flex-1 bg-gray-50 rounded-xl p-2 h-10 min-h-0 text-sm")
                 ui.button("Copiar", on_click=copiar_ruta)
                 ui.button("Abrir carpeta", on_click=abrir_carpeta)


### PR DESCRIPTION
## Summary
- replace the deprecated `readonly` argument on the desktop app input with the supported `.props('readonly')` chain
- align the web interface input with the same `.props('readonly')` usage for compatibility with current NiceGUI

## Testing
- python -c "import nicegui,sys; print('NiceGUI', nicegui.__version__, 'Python', sys.version)"
- python -m rentabilidad.gui.app *(fails: NiceGUI raises "You must call ui.run()" because the module is pre-imported via `rentabilidad.gui.__init__`)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ba0249e48323aa7b1c3476731c35