### PR TITLE
Fix NiceGUI startup by adjusting main guards

### DIFF
--- a/rentabilidad/gui/__main__.py
+++ b/rentabilidad/gui/__main__.py
@@ -2,6 +2,5 @@ from __future__ import annotations
 
 from .app import main
 
-
-if __name__ == "__main__":  # pragma: no cover
+if __name__ in {"__main__", "__mp_main__"}:  # pragma: no cover
     main()

--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -142,8 +142,7 @@ with ui.column().classes("max-w-5xl mx-auto py-6 gap-6"):
 
 
 def main() -> None:  # pragma: no cover - entrada manual
-    ui.run()
+    ui.run(reload=False)
 
-
-if __name__ == "__main__":  # pragma: no cover
+if __name__ in {"__main__", "__mp_main__"}:  # pragma: no cover
     main()

--- a/rentabilidad/gui/web.py
+++ b/rentabilidad/gui/web.py
@@ -190,11 +190,10 @@ def main() -> None:  # pragma: no cover - punto de entrada manual
     """Ejecuta la aplicación NiceGUI."""
 
     setup_ui()
-    ui.run()
+    ui.run(reload=False)
 
 
 __all__ = ["RUTA_PLANTILLA", "setup_ui", "agregar_log", "touch_last_update", "main"]
 
-
-if __name__ == "__main__":  # pragma: no cover
+if __name__ in {"__main__", "__mp_main__"}:  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- allow NiceGUI entrypoints to work with multiprocessing by updating the __main__ guards
- disable NiceGUI auto-reload in the manual entrypoints to avoid missing run configuration errors

## Testing
- python -m rentabilidad.gui
- python -m rentabilidad.gui.web

------
https://chatgpt.com/codex/tasks/task_e_68d1be9c79748323a5e2a1e05ff1427e