### PR TITLE
Abrir la GUI en una ventana nativa

### DIFF
--- a/rentabilidad/gui/web.py
+++ b/rentabilidad/gui/web.py
@@ -187,10 +187,16 @@ def touch_last_update() -> None:
 
 
 def main() -> None:  # pragma: no cover - punto de entrada manual
-    """Ejecuta la aplicación NiceGUI."""
+    """Ejecuta la aplicación NiceGUI dentro de una ventana nativa."""
 
     setup_ui()
-    ui.run(reload=False)
+    ui.run(
+        reload=False,
+        native=True,
+        show=False,
+        title="Rentabilidad",
+        window_size=(1280, 720),
+    )
 
 
 __all__ = ["RUTA_PLANTILLA", "setup_ui", "agregar_log", "touch_last_update", "main"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nicegui==2.0.0
 openpyxl==3.1.5
 pandas==2.3.2
 pydantic==2.7.4
+pywebview==6.0


### PR DESCRIPTION
## Summary
- ejecuta la aplicación de NiceGUI en modo nativo para abrir una ventana en lugar del navegador
- añade pywebview como dependencia necesaria para soportar la ventana nativa

## Testing
- python -m compileall rentabilidad/gui/web.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c36e92d883238a380c6a1edd2907