### PR TITLE
Mantener consola abierta tras fallos en GUI

### DIFF
--- a/run_gui.bat
+++ b/run_gui.bat
@@ -11,3 +11,12 @@ if not exist "%PY%" (
 )
 
 "%PY%" -m rentabilidad.gui.app
+set ERR=%ERRORLEVEL%
+
+if not "%ERR%"=="0" (
+  echo Ocurrio un error durante la ejecucion. Codigo: %ERR%
+  pause
+  exit /b %ERR%
+)
+
+pause


### PR DESCRIPTION
## Summary
- capturo el código de salida tras iniciar la aplicación de la GUI
- agrego manejo de error que muestra un mensaje, espera y sale con el mismo código
- dejo una pausa final para mantener la ventana abierta incluso cuando no hay errores

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2f3f9a1c48323a1963b049428d489