### PR TITLE
Corregir detección de encabezados en ExcelRepo

### DIFF
--- a/rentabilidad/infra/excel_repo.py
+++ b/rentabilidad/infra/excel_repo.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from numbers import Number
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+import re
+import unicodedata
 
 from openpyxl import load_workbook
 
@@ -17,6 +21,215 @@ def _limpiar_texto(valor) -> str:
     if texto.endswith(".0") and texto.replace(".0", "").isdigit():
         return texto[:-2]
     return texto
+
+
+def _normalize_header(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    normalized = unicodedata.normalize("NFKD", text)
+    without_accents = "".join(
+        ch for ch in normalized if not unicodedata.combining(ch)
+    )
+    cleaned = re.sub(r"[^0-9a-z]+", " ", without_accents.lower())
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _guess_map(header_map: Dict[str, Tuple[str, int]]) -> Dict[str, Optional[int]]:
+    def pick(*candidates: str, contains: Tuple[str, ...] = ()) -> Optional[int]:
+        for candidate in candidates:
+            normalized = _normalize_header(candidate)
+            if normalized in header_map:
+                return header_map[normalized][1]
+        if contains:
+            needles = tuple(_normalize_header(c) for c in contains if c)
+            for norm_key, (_, idx) in header_map.items():
+                for needle in needles:
+                    if needle and needle in norm_key:
+                        return idx
+        return None
+
+    return {
+        "nit": pick("nit", "nit cliente", "identificacion", "identificación"),
+        "sucursal": pick(
+            "sucursal",
+            "suc",
+            "pto de venta",
+            "punto de venta",
+            contains=("suc", "punto", "zona"),
+        ),
+        "cliente_combo": pick(
+            "nit - sucursal - cliente",
+            "cliente sucursal",
+            "cliente nit",
+            contains=("cliente", "sucursal"),
+        ),
+        "cliente": pick("cliente", "razon social", "razón social", "nombre cliente"),
+        "linea": pick("linea", "línea"),
+        "grupo": pick("grupo", "grupo descripción", contains=("grupo",)),
+        "producto": pick(
+            "producto",
+            "cod producto",
+            "cod. producto",
+            "codigo producto",
+            "código producto",
+            contains=("product",),
+        ),
+        "descripcion": pick(
+            "descripcion",
+            "descripción",
+            "nombre producto",
+            "item",
+            "referencia",
+            contains=("descr", "producto"),
+        ),
+        "cantidad": pick("cantidad", "cant"),
+        "ventas": pick(
+            "ventas",
+            "subtotal sin iva",
+            "total sin iva",
+            "valor venta",
+            "base",
+        ),
+        "costos": pick("costos", "costo", "costo total", "costo sin iva"),
+        "renta": pick(
+            "% renta",
+            "renta",
+            "rentabilidad",
+            "rentabilidad venta",
+            contains=("rentab", "renta"),
+        ),
+        "utili": pick(
+            "% utili",
+            "utili",
+            "utilidad",
+            "utilidad %",
+            "utilidad porcentaje",
+            contains=("utili", "utilid", "util"),
+        ),
+        "vendedor": pick(
+            "vendedor",
+            "nom vendedor",
+            "nombre vendedor",
+            "cod vendedor",
+            "cod. vendedor",
+            contains=("vendedor",),
+        ),
+    }
+
+
+def _find_header_row(hoja) -> Tuple[Optional[int], Dict[str, Tuple[str, int]], Dict[str, Optional[int]]]:
+    max_row = min(hoja.max_row or 0, 80)
+    for row_idx, values in enumerate(
+        hoja.iter_rows(min_row=1, max_row=max_row, values_only=True),
+        start=1,
+    ):
+        header_map: Dict[str, Tuple[str, int]] = {}
+        non_empty = 0
+        for col_idx, value in enumerate(values, start=1):
+            text = _limpiar_texto(value)
+            if not text:
+                continue
+            norm = _normalize_header(text)
+            if not norm:
+                continue
+            header_map.setdefault(norm, (text, col_idx))
+            non_empty += 1
+        if non_empty < 3:
+            continue
+        mapping = _guess_map(header_map)
+        has_cliente = mapping.get("cliente") or mapping.get("cliente_combo")
+        has_desc = mapping.get("descripcion") or mapping.get("producto")
+        has_ventas = mapping.get("ventas")
+        if has_cliente and has_desc and has_ventas:
+            return row_idx, header_map, mapping
+    return None, {}, {}
+
+
+def _resolve_sheet(libro, desired_name: Optional[str]):
+    checked = set()
+    candidates = []
+    if desired_name:
+        try:
+            candidates.append(libro[desired_name])
+        except KeyError:
+            pass
+        normalized_target = _normalize_header(desired_name)
+        compact_target = normalized_target.replace(" ", "")
+        for sheet in libro.worksheets:
+            sheet_norm = _normalize_header(sheet.title)
+            if sheet_norm == normalized_target or sheet_norm.replace(" ", "") == compact_target:
+                candidates.append(sheet)
+    candidates.extend(libro.worksheets)
+
+    for sheet in candidates:
+        title = sheet.title
+        if title in checked:
+            continue
+        checked.add(title)
+        header_row, header_map, mapping = _find_header_row(sheet)
+        if header_row is not None:
+            return sheet, header_row, header_map, mapping
+
+    sheet = libro.worksheets[0]
+    header_row, header_map, mapping = _find_header_row(sheet)
+    return sheet, header_row, header_map, mapping
+
+
+def _parse_numeric(value, *, is_percent: bool = False) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, Number):
+        result = float(value)
+    else:
+        text = str(value).strip()
+        if not text:
+            return 0.0
+        has_percent = "%" in text
+        cleaned = re.sub(r"[^0-9,.-]+", "", text)
+        if cleaned.count(",") and cleaned.count("."):
+            if cleaned.rfind(",") > cleaned.rfind("."):
+                cleaned = cleaned.replace(".", "")
+                cleaned = cleaned.replace(",", ".")
+            else:
+                cleaned = cleaned.replace(",", "")
+        else:
+            cleaned = cleaned.replace(",", ".")
+        try:
+            result = float(cleaned)
+        except ValueError:
+            return 0.0
+        if has_percent and not is_percent:
+            result /= 100
+    if is_percent:
+        if isinstance(value, str) and "%" in value:
+            return result / 100 if result else 0.0
+        if abs(result) > 1:
+            return result / 100
+    return result
+
+
+def _split_cliente_combo(value) -> Tuple[str, str, str]:
+    texto = _limpiar_texto(value)
+    if not texto:
+        return "", "", ""
+
+    match = re.match(r"^(\d+)\s*[-–]\s*(.*?)\s*[-–]\s*(.*)$", texto)
+    if match:
+        nit, sucursal, cliente = match.groups()
+        return nit.strip(), sucursal.strip(), cliente.strip()
+
+    parts = [part.strip() for part in re.split(r"[-–]", texto) if part.strip()]
+    if len(parts) >= 3:
+        return parts[0], parts[1], parts[2]
+    if len(parts) == 2:
+        first, second = parts
+        if first.isdigit():
+            return first, "", second
+        return "", first, second
+    return "", "", texto
 
 
 @dataclass
@@ -50,20 +263,71 @@ class ExcelRepo:
             return []
 
         libro = load_workbook(archivo, data_only=True, read_only=True)
-        try:
-            hoja = libro[self.hoja]
-        except KeyError:
-            hoja = libro[libro.sheetnames[0]]
+        hoja, header_row, _, mapping = _resolve_sheet(libro, self.hoja)
+
+        mapping = mapping or {}
+        if not mapping:
+            mapping = {
+                "nit": 1,
+                "sucursal": 2,
+                "cliente": 3,
+                "linea": 4,
+                "grupo": 5,
+                "producto": 6,
+                "descripcion": 7,
+                "cantidad": 8,
+                "ventas": 9,
+                "costos": 10,
+                "renta": 11,
+                "utili": 12,
+            }
+        mapping.setdefault("cliente_combo", None)
+        mapping.setdefault("vendedor", None)
+
+        start_row = (header_row + 1) if header_row else 8
+        max_required = max((idx for idx in mapping.values() if idx), default=12)
 
         filas: List[Dict] = []
         try:
-            for valores in hoja.iter_rows(min_row=8, values_only=True):
-                nit, sucursal, cliente, linea, grupo, producto, descripcion, cantidad, ventas, costos, renta_pct, utilidad_pct, *_ = (
-                    list(valores) + [None] * 5
+            for valores in hoja.iter_rows(min_row=start_row, values_only=True):
+                fila = list(valores)
+                if len(fila) < max_required:
+                    fila.extend([None] * (max_required - len(fila)))
+
+                def take(name: str):
+                    idx = mapping.get(name)
+                    if not idx:
+                        return None
+                    pos = idx - 1
+                    if pos < 0 or pos >= len(fila):
+                        return None
+                    return fila[pos]
+
+                cliente_combo_val = take("cliente_combo")
+                combo_nit, combo_sucursal, combo_cliente = _split_cliente_combo(
+                    cliente_combo_val
                 )
-                texto_cliente = _limpiar_texto(cliente)
-                texto_descripcion = _limpiar_texto(descripcion)
-                texto_linea = _limpiar_texto(linea)
+
+                nit_raw = take("nit")
+                if mapping.get("nit") == mapping.get("cliente_combo") or not _limpiar_texto(nit_raw):
+                    nit_raw = combo_nit
+
+                sucursal_raw = take("sucursal")
+                if mapping.get("sucursal") == mapping.get("cliente_combo") or not _limpiar_texto(sucursal_raw):
+                    sucursal_raw = combo_sucursal
+
+                cliente_raw = take("cliente")
+                if mapping.get("cliente") == mapping.get("cliente_combo") or not _limpiar_texto(cliente_raw):
+                    cliente_raw = combo_cliente
+                descripcion_raw = take("descripcion") or take("producto")
+                linea_raw = take("linea")
+                grupo_raw = take("grupo")
+                producto_raw = take("producto")
+                vendedor_raw = take("vendedor")
+
+                texto_cliente = _limpiar_texto(cliente_raw)
+                texto_descripcion = _limpiar_texto(descripcion_raw)
+                texto_linea = _limpiar_texto(linea_raw)
 
                 if not texto_cliente or not texto_descripcion:
                     continue
@@ -74,35 +338,22 @@ class ExcelRepo:
                 if texto_linea.lower().startswith("total"):
                     continue
 
-                cantidad_num = float(cantidad or 0)
-                ventas_num = float(ventas or 0)
-                costos_num = float(costos or 0)
-
-                def _normalizar_pct(valor) -> float:
-                    if valor is None:
-                        return 0.0
-                    try:
-                        numero = float(valor)
-                    except (TypeError, ValueError):
-                        return 0.0
-                    return numero / 100 if abs(numero) > 1 else numero
-
                 filas.append(
                     {
-                        "nit": _limpiar_texto(nit),
-                        "sucursal": _limpiar_texto(sucursal),
+                        "nit": _limpiar_texto(nit_raw),
+                        "sucursal": _limpiar_texto(sucursal_raw),
                         "cliente": texto_cliente,
                         "linea": texto_linea,
-                        "grupo": _limpiar_texto(grupo),
-                        "producto": _limpiar_texto(producto),
+                        "grupo": _limpiar_texto(grupo_raw),
+                        "producto": _limpiar_texto(producto_raw),
                         "descripcion": texto_descripcion,
-                        "cantidad": cantidad_num,
-                        "ventas": ventas_num,
-                        "costos": costos_num,
+                        "cantidad": _parse_numeric(take("cantidad")),
+                        "ventas": _parse_numeric(take("ventas")),
+                        "costos": _parse_numeric(take("costos")),
                         "descuento": 0.0,
-                        "vendedor": "",
-                        "renta_pct": _normalizar_pct(renta_pct),
-                        "utilidad_pct": _normalizar_pct(utilidad_pct),
+                        "vendedor": _limpiar_texto(vendedor_raw),
+                        "renta_pct": _parse_numeric(take("renta"), is_percent=True),
+                        "utilidad_pct": _parse_numeric(take("utili"), is_percent=True),
                     }
                 )
         finally:

--- a/tests/test_excel_repo.py
+++ b/tests/test_excel_repo.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook
+
+from rentabilidad.infra.excel_repo import ExcelRepo
+
+
+def _crear_excz(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Hoja 1"
+
+    ws.append(["Reporte generado", "", "", ""])
+    ws.append(["", "", "", ""])
+    ws.append(["", "", "", ""])
+
+    ws.append(
+        [
+            "Nit - Sucursal - Cliente",
+            "Descripción",
+            "Cantidad",
+            "Ventas",
+            "Costos",
+            "% Renta",
+            "% Utili.",
+            "Línea",
+            "Grupo",
+            "Producto",
+        ]
+    )
+
+    ws.append(
+        [
+            "123456 - PRINCIPAL - Cliente A",
+            "Producto Especial",
+            "10",
+            "1.234,50",
+            "600,00",
+            "25%",
+            "0,18",
+            "Línea Mayorista",
+            "Grupo 1",
+            "PRD-1",
+        ]
+    )
+
+    ws.append(
+        [
+            "Total",
+            "Total General",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+
+    wb.save(path)
+    wb.close()
+
+
+def test_excel_repo_detecta_encabezados_y_normaliza(tmp_path) -> None:
+    excz_path = tmp_path / "EXCZ98020240102083000.xlsx"
+    _crear_excz(excz_path)
+
+    repo = ExcelRepo(base_dir=tmp_path, prefix="EXCZ980", hoja="Hoja1")
+    filas = repo.cargar_por_fecha("2024-01-02")
+
+    assert len(filas) == 1
+    fila = filas[0]
+
+    assert fila["nit"] == "123456"
+    assert fila["sucursal"] == "PRINCIPAL"
+    assert fila["cliente"] == "Cliente A"
+    assert fila["descripcion"] == "Producto Especial"
+    assert fila["producto"] == "PRD-1"
+    assert fila["cantidad"] == pytest.approx(10.0)
+    assert fila["ventas"] == pytest.approx(1234.5)
+    assert fila["costos"] == pytest.approx(600.0)
+    assert fila["renta_pct"] == pytest.approx(0.25)
+    assert fila["utilidad_pct"] == pytest.approx(0.18)


### PR DESCRIPTION
## Summary
- ajusta `ExcelRepo` para localizar la hoja correcta y mapear columnas a partir de encabezados normalizados
- normaliza valores numéricos y porcentuales, reutilizando los datos combinados de "nit - sucursal - cliente" cuando faltan columnas dedicadas
- agrega una prueba que verifica la lectura de archivos EXCZ con encabezados variables y filas de totales

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30278ffe88323b952130b6ab2ff82