### PR TITLE
Stop falling back to latest EXCZ file for manual date requests

### DIFF
--- a/rentabilidad/infra/excel_repo.py
+++ b/rentabilidad/infra/excel_repo.py
@@ -250,11 +250,9 @@ class ExcelRepo:
 
     def _buscar_archivo(self, fecha: Optional[datetime]) -> Optional[Path]:
         finder = ExczFileFinder(self.base_dir)
-        if fecha:
-            encontrado = finder.find_for_date(self.prefix, fecha.date())
-            if encontrado:
-                return encontrado
-        return finder.find_latest(self.prefix)
+        if fecha is None:
+            return finder.find_latest(self.prefix)
+        return finder.find_for_date(self.prefix, fecha.date())
 
     def cargar_por_fecha(self, fecha: Optional[str]) -> List[Dict]:
         objetivo = self._resolver_fecha(fecha)

--- a/tests/test_excel_repo.py
+++ b/tests/test_excel_repo.py
@@ -84,3 +84,16 @@ def test_excel_repo_detecta_encabezados_y_normaliza(tmp_path) -> None:
     assert fila["costos"] == pytest.approx(600.0)
     assert fila["renta_pct"] == pytest.approx(0.25)
     assert fila["utilidad_pct"] == pytest.approx(0.18)
+
+
+def test_excel_repo_fecha_manual_inexistente_devuelve_lista_vacia(tmp_path) -> None:
+    existente = tmp_path / "EXCZ98020240101083000.xlsx"
+    _crear_excz(existente)
+
+    repo = ExcelRepo(base_dir=tmp_path, prefix="EXCZ980", hoja="Hoja1")
+
+    filas_existentes = repo.cargar_por_fecha("2024-01-01")
+    assert len(filas_existentes) == 1
+
+    filas_inexistentes = repo.cargar_por_fecha("2024-01-02")
+    assert filas_inexistentes == []


### PR DESCRIPTION
## Summary
- avoid falling back to the most recent EXCZ file when a manual date lookup fails
- return no rows when a dated lookup cannot be resolved
- add a regression test that verifies manual requests for missing dates yield an empty result

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d317aa559c832386850fd8b7b2947a