### PR TITLE
Restore ExcelRepo fallback to latest EXCZ file

### DIFF
--- a/rentabilidad/infra/excel_repo.py
+++ b/rentabilidad/infra/excel_repo.py
@@ -250,9 +250,11 @@ class ExcelRepo:
 
     def _buscar_archivo(self, fecha: Optional[datetime]) -> Optional[Path]:
         finder = ExczFileFinder(self.base_dir)
-        if fecha is None:
-            return finder.find_latest(self.prefix)
-        return finder.find_for_date(self.prefix, fecha.date())
+        if fecha:
+            encontrado = finder.find_for_date(self.prefix, fecha.date())
+            if encontrado:
+                return encontrado
+        return finder.find_latest(self.prefix)
 
     def cargar_por_fecha(self, fecha: Optional[str]) -> List[Dict]:
         objetivo = self._resolver_fecha(fecha)


### PR DESCRIPTION
## Summary
- restore `ExcelRepo._buscar_archivo` so that manual date requests fall back to the latest EXCZ file when the specific day is missing
- extend the ExcelRepo tests to cover the fallback scenario by preferring the most recently modified file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31b4304cc832393929cee80df8aa4