### PR TITLE
Avoid passing non-serializable handlers to notifications

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -246,13 +246,7 @@ def _register_bus_subscriptions() -> None:
             "multi_line": True,
         }
         if destino is not None:
-            notify_kwargs["actions"] = [
-                {
-                    "label": "Abrir",
-                    "color": "white",
-                    "handler": lambda ruta=destino: abrir_resultado(ruta),
-                }
-            ]
+            notify_text += " Usa el botón \"Abrir\" para abrir el archivo."
         ui.notify(notify_text, **notify_kwargs)
 
     def _on_error(msg: str) -> None:


### PR DESCRIPTION
## Summary
- stop attaching Python callables to NiceGUI notifications, which cannot be serialized for the client
- direct users to the existing status action button when a destination file is available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4605c67448323b0aa7bc45907b194