### PR TITLE
Permitir abrir resultado desde notificación

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -247,6 +247,17 @@ def _register_bus_subscriptions() -> None:
         }
         if destino is not None:
             notify_text += " Usa el botón \"Abrir\" para abrir el archivo."
+
+            def _abrir_desde_notificacion() -> None:
+                abrir_resultado(destino)
+
+            notify_kwargs["actions"] = [
+                {
+                    "label": "Abrir",
+                    "color": "white",
+                    "handler": _abrir_desde_notificacion,
+                }
+            ]
         ui.notify(notify_text, **notify_kwargs)
 
     def _on_error(msg: str) -> None:


### PR DESCRIPTION
## Summary
- añade una acción "Abrir" a la notificación de finalización para abrir el recurso generado
- reutiliza la lógica existente de apertura para ejecutar el comando cuando se presiona la acción

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4628ea6e88323acdc15f3b961cf07