### PR TITLE
Fix abrir informe action to avoid quoted paths

### DIFF
--- a/rentabilidad/gui/web.py
+++ b/rentabilidad/gui/web.py
@@ -78,9 +78,10 @@ def _build_open_action(ruta: Path) -> dict[str, str]:
         "color": "white",
         ":handler": (
             "async () => {"
-            "  await fetch('/api/abrir-informe?ruta=' + encodeURIComponent("
+            "  const ruta = "
             + ruta_serializada
-            + "));"
+            + ";"
+            "  await fetch('/api/abrir-informe?ruta=' + encodeURIComponent(ruta));"
             "}"
         ),
     }


### PR DESCRIPTION
## Summary
- ensure the "Abrir informe" notification action serializes the report path into a temporary JS variable before encoding
- avoid passing a JSON-quoted path to the backend so the generated Excel file can open correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d46d1b0b948323b9c35f930af8e3d2