### PR TITLE
Allow WorkbookCleaner column specifiers as letters

### DIFF
--- a/rentabilidad/services/products.py
+++ b/rentabilidad/services/products.py
@@ -56,8 +56,8 @@ class ProductGenerationConfig:
     base_path: str
     log_path: str
     credentials: SiigoCredentials
-    activo_column: str
-    keep_columns: Sequence[int]
+    activo_column: int | str
+    keep_columns: Sequence[int | str]
 
 
 class ExcelSiigoFacade:
@@ -127,9 +127,9 @@ class ExcelSiigoFacade:
 class WorkbookCleaner:
     """Responsable de filtrar columnas y filas en el archivo generado."""
 
-    def __init__(self, activo_column: str, keep_columns: Iterable[int]):
-        self._activo_idx = column_index_from_string(activo_column)
-        self._keep_columns = {int(idx) for idx in keep_columns}
+    def __init__(self, activo_column: int | str, keep_columns: Iterable[int | str]):
+        self._activo_idx = self._resolve_column(activo_column)
+        self._keep_columns = {self._resolve_column(idx) for idx in keep_columns}
         self._keep_columns.add(self._activo_idx)
 
     def clean(self, file_path: Path) -> None:
@@ -178,6 +178,30 @@ class WorkbookCleaner:
         if isinstance(value, str):
             return value.strip().upper()
         return str(value).strip().upper()
+
+    @staticmethod
+    def _resolve_column(value: int | str) -> int:
+        """Convierte ``value`` en un índice de columna de Excel (1-based)."""
+
+        if isinstance(value, int):
+            if value < 1:
+                raise ValueError("El índice de columna debe ser mayor o igual a 1")
+            return value
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                raise ValueError("El identificador de columna no puede estar vacío")
+            if text.isdigit():
+                idx = int(text)
+            else:
+                try:
+                    idx = column_index_from_string(text)
+                except ValueError as exc:  # pragma: no cover - conversión de openpyxl
+                    raise ValueError(f"Columna inválida: {value!r}") from exc
+            if idx < 1:
+                raise ValueError("El índice de columna debe ser mayor o igual a 1")
+            return idx
+        raise TypeError("El identificador de columna debe ser entero o cadena")
 
 
 @contextmanager

--- a/tests/test_workbook_cleaner.py
+++ b/tests/test_workbook_cleaner.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+
+from rentabilidad.services.products import WorkbookCleaner
+
+
+def _crear_libro(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Productos"
+    ws.append(["COD", "DESCRIPCIÓN", "ACTIVO", "PRECIO", "OTRA"])
+    ws.append(["P-1", "Producto 1", "S", 120.0, "IGNORAR"])
+    ws.append(["P-2", "Producto 2", "n", 30.0, "IGNORAR"])
+    wb.save(path)
+    wb.close()
+
+
+def test_workbook_cleaner_acepta_columnas_en_letras(tmp_path) -> None:
+    destino = tmp_path / "productos.xlsx"
+    _crear_libro(destino)
+
+    cleaner = WorkbookCleaner(activo_column="C", keep_columns=["A", "4"])
+    cleaner.clean(destino)
+
+    libro = load_workbook(destino)
+    hoja = libro.active
+
+    assert hoja.max_row == 2
+    assert hoja.max_column == 3
+    assert [hoja.cell(1, col).value for col in range(1, 4)] == ["COD", "ACTIVO", "PRECIO"]
+    assert [hoja.cell(2, col).value for col in range(1, 4)] == ["P-1", "S", 120.0]
+
+    libro.close()
+
+
+def test_workbook_cleaner_acepta_columna_activo_numerica(tmp_path) -> None:
+    destino = tmp_path / "productos.xlsx"
+    _crear_libro(destino)
+
+    cleaner = WorkbookCleaner(activo_column="3", keep_columns=[1, "4", 5])
+    cleaner.clean(destino)
+
+    libro = load_workbook(destino)
+    hoja = libro.active
+
+    assert hoja.max_row == 2
+    assert hoja.max_column == 4
+    assert [hoja.cell(1, col).value for col in range(1, 5)] == [
+        "COD",
+        "ACTIVO",
+        "PRECIO",
+        "OTRA",
+    ]
+
+    libro.close()


### PR DESCRIPTION
## Summary
- allow WorkbookCleaner to accept column specifiers provided as Excel-style letters or numeric strings
- update configuration typing and normalize column handling to validate inputs
- add regression tests covering column letter usage and numeric strings for the active column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59d5a429c8323a95a95bd5cbbe63e