### PR TITLE
Add explicit check for missing ExcelSIIGO output

### DIFF
--- a/rentabilidad/services/products.py
+++ b/rentabilidad/services/products.py
@@ -276,6 +276,12 @@ class ProductListingService:
         print(f"INFO: Ejecutando ExcelSIIGO para generar {output_path}")
         with safe_backup(output_path):
             self._facade.run(output_path, target_date.strftime("%Y"))
+            if not output_path.exists():
+                raise FileNotFoundError(
+                    "ExcelSIIGO finalizó sin generar el archivo esperado en "
+                    f"{output_path}. Verifica la configuración del proceso o los permisos "
+                    "de escritura antes de reintentar."
+                )
             print("INFO: Limpiando el archivo generado...")
             self._cleaner.clean(output_path)
         print(f"OK: Archivo final listo en {output_path}")


### PR DESCRIPTION
## Summary
- add a post-execution check to detect when ExcelSIIGO fails to create the expected workbook
- raise a descriptive FileNotFoundError guiding users to review configuration and permissions before cleaning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fb220e348323862ed34af25ff998