### PR TITLE
Fix notify action to open generated reports directly

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -126,22 +126,15 @@ def update_status(
     _toggle_status_action(target)
 
 
-def _build_notify_open_action(destino: Path) -> dict[str, str]:
-    ruta = json.dumps(str(destino))
+def _build_notify_open_action(destino: Path) -> dict[str, object]:
+    def _handler() -> None:
+        if abrir_resultado(destino):
+            touch_last_update()
+
     return {
         "label": "Abrir",
         "color": "white",
-        ":handler": (
-            "async () => {"
-            "  await fetch('/api/abrir-recurso', {"
-            "    method: 'POST',"
-            "    headers: { 'Content-Type': 'application/json' },"
-            "    body: JSON.stringify({ ruta: "
-            + ruta
-            + " }),"
-            "  });"
-            "}"
-        ),
+        "handler": _handler,
     }
 
 


### PR DESCRIPTION
## Summary
- update the notification "Abrir" action to invoke the server-side handler directly
- ensure the action updates the last-run timestamp when the report opens successfully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fbcc27b88323bca65360a8930095