### PR TITLE
Fix notification action handler serialization

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -127,14 +127,25 @@ def update_status(
 
 
 def _build_notify_open_action(destino: Path) -> dict[str, object]:
-    def _handler() -> None:
-        if abrir_resultado(destino):
-            touch_last_update()
-
+    ruta_serializada = json.dumps(str(destino))
     return {
         "label": "Abrir",
         "color": "white",
-        "handler": _handler,
+        ":handler": (
+            "async () => {"
+            "  try {"
+            "    await fetch('/api/abrir-recurso', {"
+            "      method: 'POST',"
+            "      headers: {'Content-Type': 'application/json'},"
+            "      body: JSON.stringify({ruta: "
+            + ruta_serializada
+            + "}),"
+            "    });"
+            "  } catch (error) {"
+            "    console.error('No se pudo abrir el recurso generado.', error);"
+            "  }"
+            "}"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- replace the NiceGUI notification action handler with a JavaScript callback so the payload can be serialized
- keep the ability to open generated resources by calling the existing API endpoint from the notification action

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fe2bc34883238ecb71a1365fe682