### PR TITLE
Fix notification open action

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -126,26 +126,16 @@ def update_status(
     _toggle_status_action(target)
 
 
+def _handle_notify_open_action(destino: Path) -> None:
+    if abrir_resultado(destino):
+        touch_last_update()
+
+
 def _build_notify_open_action(destino: Path) -> dict[str, object]:
-    ruta_serializada = json.dumps(str(destino))
     return {
         "label": "Abrir",
         "color": "white",
-        ":handler": (
-            "async () => {"
-            "  try {"
-            "    await fetch('/api/abrir-recurso', {"
-            "      method: 'POST',"
-            "      headers: {'Content-Type': 'application/json'},"
-            "      body: JSON.stringify({ruta: "
-            + ruta_serializada
-            + "}),"
-            "    });"
-            "  } catch (error) {"
-            "    console.error('No se pudo abrir el recurso generado.', error);"
-            "  }"
-            "}"
-        ),
+        "handler": lambda destino=destino: _handle_notify_open_action(destino),
     }
 
 


### PR DESCRIPTION
## Summary
- ensure notification action reuses server-side open logic instead of a JavaScript fetch
- update notification handler to reuse the same function as the status button and refresh the timestamp on success

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8049cc03c83239974271e7b495f07