### PR TITLE
Ensure UI status handles failed runs

### DIFF
--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -900,6 +900,8 @@ def build_ui() -> None:
                                         "Proceso completado",
                                         open_path=resultado.ruta_salida,
                                     )
+                                else:
+                                    update_status("error", "Revisa los registros")
 
                             ui.button(
                                 "Generar informe automático",
@@ -965,6 +967,8 @@ def build_ui() -> None:
                                         "Proceso completado",
                                         open_path=resultado.ruta_salida,
                                     )
+                                else:
+                                    update_status("error", "Revisa los registros")
 
                             ui.button(
                                 "Generar informe manual",
@@ -1008,6 +1012,8 @@ def build_ui() -> None:
                                         "Proceso completado",
                                         open_path=ruta,
                                     )
+                                else:
+                                    update_status("error", "Revisa los registros")
 
                             ui.button(
                                 "Generar listado de productos",


### PR DESCRIPTION
## Summary
- mark the UI status as error when report or product generation fails, even after background handling
- keep the successful path unchanged so users still get shortcuts when a file is produced

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dafdfdf0f08323aa6261970bf5e567