### PR TITLE
feat: show latest generated outputs in activity log

### DIFF
--- a/rentabilidad/infra/fs.py
+++ b/rentabilidad/infra/fs.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Iterable
 
 
 def ayer_str() -> str:
@@ -8,3 +9,38 @@ def ayer_str() -> str:
 
 def asegurar_carpeta(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _iter_files(root: Path, patterns: Iterable[str]) -> list[Path]:
+    if not root.exists():
+        return []
+    files: list[Path] = []
+    for pattern in patterns:
+        files.extend(
+            path
+            for path in root.rglob(pattern)
+            if path.is_file() and not path.name.startswith("~$")
+        )
+    return files
+
+
+def _find_latest(root: Path, patterns: Iterable[str]) -> Path | None:
+    candidates = _iter_files(root, patterns)
+    if not candidates:
+        return None
+    try:
+        return max(candidates, key=lambda item: item.stat().st_mtime)
+    except OSError:
+        return None
+
+
+def find_latest_informe(root: Path) -> Path | None:
+    """Devuelve el informe más reciente dentro de ``root``."""
+
+    return _find_latest(root, ("*.xlsx",))
+
+
+def find_latest_producto(root: Path) -> Path | None:
+    """Devuelve el listado de productos más reciente dentro de ``root``."""
+
+    return _find_latest(root, ("*.xlsx",))


### PR DESCRIPTION
## Summary
- add filesystem helpers to detect the most recent informes and product listings
- replace the process summary with cards that surface the latest report and product list with quick access actions
- keep the activity log panel height consistent even when there are no entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbfe080d4c8323b508086827ff10a8