### PR TITLE
Harden ExcelSIIGO invocation and output validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
 
 - Variables de entorno (opcionales) que ajustan las rutas por defecto:
   - `SIIGO_DIR`: carpeta donde está instalado SIIGO (por defecto `C:\\Siigo`).
+  - `SIIGO_COMMAND`: nombre del ejecutable de SIIGO (por defecto `ExcelSIIGO.exe`).
   - `SIIGO_BASE`: ruta base pasada como primer parámetro a `ExcelSIIGO`
     (por defecto `D:\\SIIWI01`).
   - `PRODUCTOS_DIR`: carpeta destino de los Excel generados

--- a/rentabilidad/config.py
+++ b/rentabilidad/config.py
@@ -70,6 +70,7 @@ class Settings:
             credentials=credenciales,
             activo_column=activo_column,
             keep_columns=keep_columns,
+            siigo_command=os.environ.get("SIIGO_COMMAND", "ExcelSIIGO.exe"),
             siigo_output_filename=os.environ.get("SIIGO_OUTPUT_FILENAME", "ProductosMesDia.xlsx"),
             wait_timeout=_read_float_env("SIIGO_WAIT_TIMEOUT", 60.0),
             wait_interval=_read_float_env("SIIGO_WAIT_INTERVAL", 0.2),

--- a/tests/test_product_listing_service.py
+++ b/tests/test_product_listing_service.py
@@ -17,9 +17,15 @@ from rentabilidad.services.products import (
 
 
 class _DelayedFacade:
-    def __init__(self, delay: float = 0.0, create_file: bool = True) -> None:
+    def __init__(
+        self,
+        delay: float = 0.0,
+        create_file: bool = True,
+        payload_size: int = 2048,
+    ) -> None:
         self._delay = delay
         self._create_file = create_file
+        self._payload_size = payload_size
 
     def run(self, output_path: Path, year: str) -> None:  # noqa: ARG002 - firma requerida
         if not self._create_file:
@@ -28,7 +34,7 @@ class _DelayedFacade:
         def _writer() -> None:
             time.sleep(self._delay)
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(b"contenido")
+            output_path.write_bytes(b"0" * self._payload_size)
 
         thread = threading.Thread(target=_writer, daemon=True)
         thread.start()
@@ -100,7 +106,7 @@ def test_siigo_output_filename_replaces_placeholders(tmp_path: Path) -> None:
         def run(self, output_path: Path, year: str) -> None:  # noqa: ARG002 - compatibilidad de firma
             captured_paths.append(output_path)
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(b"contenido")
+            output_path.write_bytes(b"0" * 2048)
 
     service._facade = _CapturingFacade()
     service._config.siigo_output_filename = "ProductosMesDia.xlsx"
@@ -122,7 +128,7 @@ def test_generate_fails_when_file_never_appears(tmp_path: Path) -> None:
         service.generate(date(2024, 1, 15))
 
 
-def test_facade_quotes_windows_paths(monkeypatch, tmp_path: Path) -> None:
+def test_facade_runs_with_cwd_and_executable(monkeypatch, tmp_path: Path) -> None:
     from rentabilidad.services import products as products_module
 
     siigo_dir = tmp_path / "Siigo Dir"
@@ -150,7 +156,7 @@ def test_facade_quotes_windows_paths(monkeypatch, tmp_path: Path) -> None:
 
     facade = ExcelSiigoFacade(config)
 
-    captured_commands: list[list[str]] = []
+    captured: dict[str, object] = {}
 
     class DummyResult:
         returncode = 0
@@ -158,17 +164,77 @@ def test_facade_quotes_windows_paths(monkeypatch, tmp_path: Path) -> None:
         stderr = ""
 
     def fake_run(command, **kwargs):  # noqa: ANN001 - firma flexible para imitar subprocess.run
-        captured_commands.append(command)
+        captured["command"] = command
+        captured["kwargs"] = kwargs
         return DummyResult()
 
-    monkeypatch.setattr(products_module, "os", type("FakeOS", (), {"name": "nt"}))
     monkeypatch.setattr(products_module.subprocess, "run", fake_run)
 
     facade.run(output_path, "2024")
 
-    assert captured_commands, "El comando de ExcelSIIGO debe ejecutarse"
-    cmd = captured_commands[0]
-    assert cmd[0:3] == ["cmd.exe", "/d", "/c"]
-    assert cmd[3].startswith("cd /d ")
-    assert '"cd"' not in cmd[3], "El comando cd no debe ir entre comillas"
-    assert f'"{siigo_dir}"' in cmd[3]
+    assert captured, "El comando de ExcelSIIGO debe ejecutarse"
+    cmd = captured["command"]
+    kwargs = captured["kwargs"]
+    assert cmd[0] == str(siigo_dir / "ExcelSIIGO.exe")
+    assert kwargs.get("cwd") == str(siigo_dir)
+    assert kwargs.get("capture_output") is True
+    assert kwargs.get("text") is True
+
+
+def test_facade_accepts_custom_executable(monkeypatch, tmp_path: Path) -> None:
+    from rentabilidad.services import products as products_module
+
+    siigo_dir = tmp_path / "Siigo"
+    siigo_dir.mkdir()
+    output_path = tmp_path / "salida.xlsx"
+
+    credentials = SiigoCredentials(
+        reporte="REP",
+        empresa="EMP",
+        usuario="USR",
+        clave="PWD",
+        estado_param="S",
+        rango_ini="0001",
+        rango_fin="9999",
+    )
+
+    config = ProductGenerationConfig(
+        siigo_dir=siigo_dir,
+        base_path="D:\\SIIWI01\\",
+        log_path="D:\\SIIWI01\\LOGS\\log_catalogos.txt",
+        credentials=credentials,
+        activo_column=1,
+        keep_columns=(1,),
+        siigo_command="Excel Custom.exe",
+    )
+
+    facade = ExcelSiigoFacade(config)
+
+    captured: dict[str, object] = {}
+
+    class DummyResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command, **kwargs):  # noqa: ANN001 - firma flexible
+        captured["command"] = command
+        return DummyResult()
+
+    monkeypatch.setattr(products_module.subprocess, "run", fake_run)
+
+    facade.run(output_path, "2024")
+
+    assert captured, "Debe ejecutarse ExcelSIIGO"
+    cmd = captured["command"]
+    assert cmd[0].endswith("Excel Custom.exe")
+
+
+def test_generate_fails_when_file_too_small(tmp_path: Path) -> None:
+    service = _build_service(tmp_path)
+    service._facade = _DelayedFacade(payload_size=10)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        service.generate(date(2024, 3, 1))
+
+    assert "No se generó el archivo de productos" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- execute ExcelSIIGO using an explicit working directory, captured output, and log tail diagnostics
- verify that the generated Excel file exists with a reasonable size before cleaning
- update product listing service tests to reflect the new execution flow and failure handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4e602b30832390cc5831a8647f40