### PR TITLE
Oculta la hoja VENDEDORES en el libro de rentabilidad

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -599,6 +599,7 @@ def _update_vendedores_sheet(
         src_wb.close()
 
     ws = wb[sheet_name]
+    ws.sheet_state = "hidden"
     ws.delete_rows(1, ws.max_row)
 
     rows_written = 0


### PR DESCRIPTION
## Summary
- asegura que la hoja VENDEDORES del libro quede siempre oculta al actualizarse

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e02bd1063c8323b01e89896ac88e5f