### PR TITLE
Fix parsing of localized price formats

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -339,7 +339,22 @@ def _coerce_float(value):
     text = str(value).strip()
     if not text:
         return None
-    sanitized = text.replace("$", "").replace(",", "").replace(" ", "")
+
+    text = text.replace("$", "").replace(" ", "")
+    if text.startswith("(") and text.endswith(")"):
+        text = f"-{text[1:-1]}"
+
+    sanitized = text.replace("'", "")
+    if "," in sanitized and "." in sanitized:
+        last_comma = sanitized.rfind(",")
+        last_dot = sanitized.rfind(".")
+        if last_comma > last_dot:
+            sanitized = sanitized.replace(".", "").replace(",", ".")
+        else:
+            sanitized = sanitized.replace(",", "")
+    elif "," in sanitized:
+        sanitized = sanitized.replace(",", ".")
+
     numeric = _try_convert_numeric(sanitized)
     if isinstance(numeric, numbers.Real):
         return float(numeric)

--- a/tests/test_price_validation.py
+++ b/tests/test_price_validation.py
@@ -1,4 +1,8 @@
-from hojas.hoja01_loader import IVA_MULTIPLIER, PRICE_TOLERANCE
+import math
+
+import pytest
+
+from hojas.hoja01_loader import IVA_MULTIPLIER, PRICE_TOLERANCE, _coerce_float
 
 
 def _diff_ratio(ventas, cantidad, expected_con_iva):
@@ -25,3 +29,18 @@ def test_wrong_quantity_triggers_price_mismatch():
     diff_ratio = _diff_ratio(ventas, cantidad, expected_con_iva)
 
     assert diff_ratio > PRICE_TOLERANCE
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("37.596,005", 37_596.005),
+        ("37596,005", 37_596.005),
+        ("1,234,567.89", 1_234_567.89),
+        ("(1.234,56)", -1_234.56),
+    ],
+)
+def test_coerce_float_supports_common_decimal_formats(raw, expected):
+    parsed = _coerce_float(raw)
+    assert parsed is not None
+    assert math.isclose(parsed, expected, rel_tol=0, abs_tol=1e-9)


### PR DESCRIPTION
## Summary
- improve the numeric coercion helper to understand comma and dot separators
- add parsing regression tests for common localized formats to keep price validation tolerant

## Testing
- pytest tests/test_price_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68e043cdd8308323ac08f2154e4b38b1