### PR TITLE
Fix quantity column detection for EXCZ imports

### DIFF
--- a/docs/price_mismatch_example.md
+++ b/docs/price_mismatch_example.md
@@ -1,0 +1,33 @@
+# Ejemplo de alerta de precio en Hoja 1
+
+La macro de carga marca en amarillo las filas en las que el precio unitario que
+se facturó difiere del precio de lista en más de 0,2 %. Esa tolerancia se
+controla con la constante `PRICE_TOLERANCE = 0.002` del cargador de la Hoja 1.
+Cuando la diferencia supera ese umbral, todo el renglón se llena de amarillo y
+la columna de observaciones muestra el mensaje
+«`Precio total menor que la lista en …`».【F:hojas/hoja01_loader.py†L49-L52】【F:hojas/hoja01_loader.py†L2292-L2330】
+
+A modo de ejemplo, la fila del cliente 0000094281893 con el producto «ESTUCO
+IMPADOC x 25 KLS BLANCO PLUS» muestra el mensaje:
+
+> Precio total menor que la lista en $78.480,25 (-7,65 %).
+
+Los números del renglón permiten reconstruir el cálculo:
+
+1. **Cantidad facturada (CANT)**: 26 unidades.
+2. **Venta total sin IVA (`VENTAS`)**: $947.798,32.
+3. **Diferencia total indicada por el mensaje**: $78.480,25.
+
+Con esos datos, el script calcula los valores unitarios sin IVA:
+
+- Precio unitario real = 947.798,32 ÷ 26 = **$36.453,78**.
+- La diferencia por unidad = 78.480,25 ÷ 26 = **$3.018,47**.
+- Precio unitario de lista = 36.453,78 + 3.018,47 = **$39.472,25**.
+
+Por último, el porcentaje de variación relativo es 3.018,47 ÷ 39.472,25 =
+0,0765, es decir **7,65 %**, que coincide con el porcentaje mostrado en el
+mensaje. Como 7,65 % es mayor que la tolerancia permitida (0,2 %), la línea se
+marca de amarillo.【F:hojas/hoja01_loader.py†L2289-L2330】
+
+Este análisis se realiza completamente en valores sin IVA, por lo que las
+cantidades y precios deben interpretarse antes de impuestos.

--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -958,6 +958,27 @@ def _guess_map(df_cols):
                         return original
 
         return None
+    quantity_col = pick(
+        "cantidad facturada",
+        "cant facturada",
+        "cantidad fact",
+        "cant fact",
+        "cantidad facturada (und)",
+        "cant facturada (und)",
+        "cantidad vendida",
+        "cant vendida",
+        contains=(
+            "cantidad fact",
+            "cant fact",
+            "cantidad vend",
+            "cant vend",
+            "cant factura",
+            "cant entrega",
+        ),
+    )
+    if not quantity_col:
+        quantity_col = pick("cantidad", "cant")
+
     return {
         "centro_costo": pick(
             "centro de costo",
@@ -986,7 +1007,7 @@ def _guess_map(df_cols):
         "linea": pick("linea", "línea"),
         "grupo": pick("grupo", "grupo descripción", contains=("grupo",)),
         "descripcion": pick("descripcion","descripción","producto","nombre producto","item"),
-        "cantidad": pick("cantidad","cant"),
+        "cantidad": quantity_col,
         "ventas": pick("ventas","subtotal sin iva","total sin iva","valor venta","base"),
         "costos": pick("costos","costo","costo total","costo sin iva"),
         "renta": pick(

--- a/tests/test_price_validation.py
+++ b/tests/test_price_validation.py
@@ -2,7 +2,12 @@ import math
 
 import pytest
 
-from hojas.hoja01_loader import IVA_MULTIPLIER, PRICE_TOLERANCE, _coerce_float
+from hojas.hoja01_loader import (
+    IVA_MULTIPLIER,
+    PRICE_TOLERANCE,
+    _coerce_float,
+    _guess_map,
+)
 
 
 def _diff_ratio(ventas, cantidad, expected_con_iva):
@@ -29,6 +34,20 @@ def test_wrong_quantity_triggers_price_mismatch():
     diff_ratio = _diff_ratio(ventas, cantidad, expected_con_iva)
 
     assert diff_ratio > PRICE_TOLERANCE
+
+
+def test_guess_map_prefers_facturada_quantity_column():
+    cols = [
+        "Nit",
+        "Descripción",
+        "Cant Pedida",
+        "Cant Fact.",
+        "Ventas",
+    ]
+
+    mapping = _guess_map(cols)
+
+    assert mapping["cantidad"] == "Cant Fact."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- prefer facturada or vendida headers when resolving the quantity column during EXCZ imports
- add a regression test to ensure Cant Fact. columns are selected for price calculations

## Testing
- pytest tests/test_price_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68e11e80bc948323b0197268cdcb5c95