### PR TITLE
Ajusta comentarios de rentabilidad

### DIFF
--- a/tests/test_hoja01_loader.py
+++ b/tests/test_hoja01_loader.py
@@ -1,0 +1,40 @@
+from hojas.hoja01_loader import (
+    _build_price_mismatch_message,
+    _build_sika_customer_message,
+    _build_vendor_mismatch_message,
+    _combine_reason_messages,
+)
+
+
+def test_build_price_mismatch_message_includes_lista() -> None:
+    message = _build_price_mismatch_message(
+        100.0, 120.0, 5, 0.2, lista_precio=1
+    )
+
+    assert "lista 1" in message
+    assert "mayor" in message
+
+
+def test_build_price_mismatch_message_without_lista() -> None:
+    message = _build_price_mismatch_message(100.0, 80.0, None, 0.2)
+
+    assert "la lista" in message
+    assert "menor" in message
+
+
+def test_build_vendor_mismatch_message_includes_code() -> None:
+    assert _build_vendor_mismatch_message("A1") == "Está creado con código A1."
+    assert _build_vendor_mismatch_message(None) is None
+
+
+def test_build_sika_customer_message_for_valid_lists() -> None:
+    assert _build_sika_customer_message(7) == "CLIENTE CONSTRUCTORA SIKA TIPO A"
+    assert _build_sika_customer_message(9) == "CLIENTE CONSTRUCTORA SIKA TIPO B"
+    assert _build_sika_customer_message(1) is None
+
+
+def test_combine_reason_messages_single_line() -> None:
+    message = _combine_reason_messages([" Uno", "Dos ", "", None])
+
+    assert message == "Uno Dos"
+    assert "\n" not in message


### PR DESCRIPTION
## Summary
- actualiza los mensajes de diferencia de precio para indicar la lista utilizada y añade comentarios para desvíos de vendedor
- agrega el comentario solicitado para clientes de lista 7 y 9 con rentabilidad baja y precio correcto
- incorpora pruebas unitarias para cubrir los nuevos generadores de mensajes
- evita que las observaciones en la columna L se dividan en varias líneas y desactiva el ajuste automático de texto

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e134832e5c83239843fc5cca7b4c47