### PR TITLE
Actualizar fuente SQL de productos a vw_productos_activos

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -68,7 +68,7 @@ DEFAULT_SQL_TERCEROS_ACTIVE_VALUE = os.environ.get(
     "SQL_TERCEROS_ACTIVE_VALUE", "A"
 )
 DEFAULT_SQL_PRECIOS_TABLE = os.environ.get(
-    "SQL_PRECIOS_TABLE", "dbo.TABLA_MAESTRO_INVENTARIOS"
+    "SQL_PRECIOS_TABLE", "dbo.vw_productos_activos"
 )
 DEFAULT_SQL_PRECIOS_ACTIVE_COLUMN = os.environ.get(
     "SQL_PRECIOS_ACTIVE_COLUMN", "ActivoInv"
@@ -3428,7 +3428,7 @@ def main():
 
         sql_precios_df = _fetch_sql_data(
             sql_config,
-            "SELECT * FROM [SiigoCat].[dbo].[TABLA_MAESTRO_INVENTARIOS]",
+            "SELECT * FROM [SiigoCat].[dbo].[vw_productos_activos]",
         )
         sql_vendedores_df = _fetch_sql_data(
             sql_config,


### PR DESCRIPTION
### Motivation
- Alinear la carga de precios/productos con la nueva vista de SIIGO `[SiigoCat].[dbo].[vw_productos_activos]`, que expone columnas `LISTA_PRECIO1..LISTA_PRECIO12` y el conjunto de campos actualizados.

### Description
- Cambié la constante por defecto `DEFAULT_SQL_PRECIOS_TABLE` para apuntar a `dbo.vw_productos_activos` en lugar de `dbo.TABLA_MAESTRO_INVENTARIOS` en `hojas/hoja01_loader.py`.
- Reemplacé la consulta SQL hardcodeada usada al obtener `sql_precios_df` para `SELECT * FROM [SiigoCat].[dbo].[vw_productos_activos]`.

### Testing
- Ejecuté la comprobación de sintaxis con `python -m py_compile /workspace/Rent/hojas/hoja01_loader.py` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998860cbde4832381c6c171128f4afa)