### PR TITLE
Preferir `NOMBRE` como columna descriptiva al sincronizar `PRECIOS` desde SQL

### DIFF
--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -1338,10 +1338,10 @@ def _guess_sql_precios_columns(df_cols):
         "descripcion",
         "descripción",
         "descripcioninv",
-        "producto",
         "nombre",
         "nombre producto",
-        contains=("descr", "producto", "item"),
+        "producto",
+        contains=("descr", "nombre", "producto", "item"),
     )
 
     price_cols = []

--- a/tests/test_hoja01_loader.py
+++ b/tests/test_hoja01_loader.py
@@ -7,6 +7,7 @@ from hojas.hoja01_loader import (
     _build_sika_customer_message,
     _build_vendor_mismatch_message,
     _combine_reason_messages,
+    _guess_sql_precios_columns,
     _load_terceros_lookup,
     _load_vendedores_document_lookup,
     _normalize_nit_value,
@@ -144,3 +145,21 @@ def test_hide_and_relocate_document_fields_hides_and_copies_columns() -> None:
     assert ws.cell(2, 13).value == "F123"
     assert ws.cell(1, 14).value == "FECHA"
     assert ws.cell(2, 14).value == "2026-02-17"
+
+
+def test_guess_sql_precios_columns_prefers_nombre_over_codigo() -> None:
+    columns = [
+        "CODIGO",
+        "LINEA",
+        "GRUPO",
+        "PRODUCTO",
+        "NOMBRE",
+        "REFERENCIA",
+        "LISTA_PRECIO1",
+        "LISTA_PRECIO2",
+    ]
+
+    descripcion, precios = _guess_sql_precios_columns(columns)
+
+    assert descripcion == "NOMBRE"
+    assert precios == ["LISTA_PRECIO1", "LISTA_PRECIO2"]


### PR DESCRIPTION
### Motivation
- Evitar que columnas con códigos o alias de producto (por ejemplo `PRODUCTO` o `CODIGO`) sean usadas como descripción al sincronizar la hoja `PRECIOS` desde resultados SQL, lo que provocaba que la hoja mostrara códigos en lugar del nombre del producto.

### Description
- Ajusté la función ` _guess_sql_precios_columns` en `hojas/hoja01_loader.py` para priorizar la detección de `nombre`/`NOMBRE` antes de `producto` y amplié los términos de búsqueda en `contains` para incluir `nombre`.
- Añadí la prueba de regresión `test_guess_sql_precios_columns_prefers_nombre_over_codigo` en `tests/test_hoja01_loader.py` para validar que conjuntos de columnas con `CODIGO, PRODUCTO, NOMBRE, LISTA_PRECIO*` elijan `NOMBRE` como descripción y detecten las columnas de precio correctamente.

### Testing
- Ejecuté `pytest -q tests/test_hoja01_loader.py` y obtuvo: `12 passed in 0.98s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988927aed08323b552ba3a4c25fbc5)