### PR TITLE
Actualizar rutas por defecto a D:\SIIWIS\SIIWI01

### DIFF
--- a/GenerarListadoProductos.bat
+++ b/GenerarListadoProductos.bat
@@ -9,7 +9,7 @@ if exist "%PROJ_DIR%.env" (
 )
 
 if not defined SIIGO_DIR set "SIIGO_DIR=C:\Siigo"
-if not defined SIIGO_BASE set "SIIGO_BASE=D:\SIIWI01"
+if not defined SIIGO_BASE set "SIIGO_BASE=D:\SIIWIS\SIIWI01"
 if not defined PRODUCTOS_DIR set "PRODUCTOS_DIR=C:\Rentabilidad\Productos"
 if not defined SIIGO_LOG set "SIIGO_LOG=%SIIGO_BASE%\LOGS\log_catalogos.txt"
 

--- a/Productos.bat
+++ b/Productos.bat
@@ -15,7 +15,7 @@ for /f %%c in ('powershell -command "(Get-Date).ToString('dd')"') do set DIA=%%c
 cd /d C:\Siigo
 
 :: ===================== PRODUCTOS ============================
-ExcelSIIGO D:\SIIWI01\ %ANO% GETINV L JUAN 0110 D:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
+ExcelSIIGO D:\SIIWIS\SIIWI01\ %ANO% GETINV L JUAN 0110 D:\SIIWIS\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
 echo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ de productos se guardan en la carpeta `Productos`.
 ### 2. Carga de EXCZ
 
 - Script principal: `hojas/hoja01_loader.py`.
-- Origen de datos: busca en `D:\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
+- Origen de datos: busca en `D:\SIIWIS\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
 - Acciones: importa el EXCZ en la Hoja 1, aplica las fórmulas necesarias y actualiza las hojas `CCOSTO` y `COD` con la misma fecha.
 
 ### 2.1 Fuente SQL Server (opcional)
@@ -105,7 +105,7 @@ python hojas/hoja01_loader.py --excel "C:\\Rentabilidad\\Informes\\Marzo\\Marzo 
   pip install -r requirements.txt
   ```
 - Archivo `PLANTILLA.xlsx` ubicado en `C:\\Rentabilidad\\`.
-- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
+- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWIS\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
 
 ## Instalación
 
@@ -167,11 +167,11 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
   - `SIIGO_DIR`: carpeta donde está instalado SIIGO (por defecto `C:\\Siigo`).
   - `SIIGO_COMMAND`: nombre del ejecutable de SIIGO (por defecto `ExcelSIIGO`).
   - `SIIGO_BASE`: ruta base pasada como primer parámetro a `ExcelSIIGO`
-    (por defecto `D:\\SIIWI01`).
+    (por defecto `D:\\SIIWIS\\SIIWI01`).
   - `PRODUCTOS_DIR`: carpeta destino de los Excel generados
     (por defecto `C:\\Rentabilidad\\Productos`).
   - `SIIGO_LOG`: ruta del archivo de log usado por `ExcelSIIGO`
-    (por defecto `D:\\SIIWI01\\LOGS\\log_catalogos.txt`).
+    (por defecto `D:\\SIIWIS\\SIIWI01\\LOGS\\log_catalogos.txt`).
   - `SIIGO_WAIT_TIMEOUT`: tiempo máximo para esperar a que se cree el archivo
     de SIIGO (por defecto `60`).
   - `SIIGO_WAIT_INTERVAL`: intervalo entre verificaciones del archivo generado

--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -41,7 +41,7 @@ from rentabilidad.infra.sql_server import (
 load_env()
 PATH_CONTEXT: PathContext = PathContextFactory(os.environ).create()
 DEFAULT_RENT_DIR = os.environ.get("RENT_DIR", str(PATH_CONTEXT.base_dir))
-DEFAULT_EXCZDIR = os.environ.get("EXCZDIR", r"D:\\SIIWI01\\LISTADOS")
+DEFAULT_EXCZDIR = os.environ.get("EXCZDIR", r"D:\\SIIWIS\\SIIWI01\\LISTADOS")
 DEFAULT_EXCZ_PREFIX = os.environ.get("EXCZPREFIX", "EXCZ980")
 DEFAULT_CCOSTO_EXCZ_PREFIX = os.environ.get("CCOSTO_EXCZPREFIX", "EXCZ979")
 DEFAULT_COD_EXCZ_PREFIX = os.environ.get("COD_EXCZPREFIX", "EXCZ978")

--- a/rentabilidad/config.py
+++ b/rentabilidad/config.py
@@ -58,7 +58,7 @@ class Settings:
         self.ruta_plantilla: Path = self.context.template_path()
         self.plantilla_hoja: str | None = os.environ.get("PLANTILLA_HOJA")
 
-        self.excz_dir: Path = Path(os.environ.get("EXCZDIR", r"D:\\SIIWI01\\LISTADOS"))
+        self.excz_dir: Path = Path(os.environ.get("EXCZDIR", r"D:\\SIIWIS\\SIIWI01\\LISTADOS"))
         self.excz_prefix: str = os.environ.get("EXCZPREFIX", "EXCZ980")
         self.excz_sheet: str = os.environ.get("EXCZ_SHEET", "Hoja1")
 
@@ -126,7 +126,7 @@ class Settings:
 
     def _build_product_config(self) -> ProductGenerationConfig:
         siigo_dir = Path(os.environ.get("SIIGO_DIR", r"C:\\Siigo"))
-        base_path = _ensure_trailing_backslash(os.environ.get("SIIGO_BASE", r"D:\\SIIWI01"))
+        base_path = _ensure_trailing_backslash(os.environ.get("SIIGO_BASE", r"D:\\SIIWIS\\SIIWI01"))
         log_path = os.environ.get("SIIGO_LOG", str(Path(base_path.rstrip("\\/")) / "LOGS" / "log_catalogos.txt"))
 
         credenciales = SiigoCredentials(

--- a/servicios/generar_listado_productos.py
+++ b/servicios/generar_listado_productos.py
@@ -59,7 +59,7 @@ def build_parser(defaults: dict[str, str | float]) -> argparse.ArgumentParser:
     parser.add_argument(
         "--siigo-base",
         default=defaults["SIIGO_BASE"],
-        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. D:\\SIIWI01)",
+        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. D:\\SIIWIS\\SIIWI01)",
     )
     parser.add_argument(
         "--productos-dir",
@@ -128,8 +128,8 @@ def _collect_defaults() -> dict[str, str | float]:
     context = PathContextFactory(os.environ).create()
     defaults = {
         "SIIGO_DIR": os.environ.get("SIIGO_DIR", r"C:\\Siigo"),
-        "SIIGO_BASE": os.environ.get("SIIGO_BASE", r"D:\\SIIWI01"),
-        "SIIGO_LOG": os.environ.get("SIIGO_LOG", str(Path(os.environ.get("SIIGO_BASE", r"D:\\SIIWI01")) / "LOGS" / "log_catalogos.txt")),
+        "SIIGO_BASE": os.environ.get("SIIGO_BASE", r"D:\\SIIWIS\\SIIWI01"),
+        "SIIGO_LOG": os.environ.get("SIIGO_LOG", str(Path(os.environ.get("SIIGO_BASE", r"D:\\SIIWIS\\SIIWI01")) / "LOGS" / "log_catalogos.txt")),
         "SIIGO_COMMAND": os.environ.get("SIIGO_COMMAND", "ExcelSIIGO"),
         "SIIGO_REPORTE": os.environ.get("SIIGO_REPORTE", "GETINV"),
         "SIIGO_EMPRESA": os.environ.get("SIIGO_EMPRESA", "L"),

--- a/tests/test_product_listing_service.py
+++ b/tests/test_product_listing_service.py
@@ -77,8 +77,8 @@ def _build_service(tmp_path: Path) -> ProductListingService:
 
     config = ProductGenerationConfig(
         siigo_dir=tmp_path,
-        base_path="D:\\SIIWI01\\",
-        log_path="D:\\SIIWI01\\LOGS\\log_catalogos.txt",
+        base_path="D:\\SIIWIS\\SIIWI01\\",
+        log_path="D:\\SIIWIS\\SIIWI01\\LOGS\\log_catalogos.txt",
         credentials=credentials,
         activo_column=1,
         keep_columns=(1,),

--- a/todo_en_un_click.bat
+++ b/todo_en_un_click.bat
@@ -8,7 +8,7 @@ if exist "%PROJ_DIR%.env" (
 )
 if not defined RENT_DIR set "RENT_DIR=C:\Rentabilidad"
 if not defined TEMPLATE set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
-if not defined EXCZDIR set "EXCZDIR=D:\SIIWI01\LISTADOS"
+if not defined EXCZDIR set "EXCZDIR=D:\SIIWIS\SIIWI01\LISTADOS"
 
 where python >nul 2>nul || (
   echo ERROR: Python no esta en PATH. Instala Python y reintenta.


### PR DESCRIPTION
### Motivation
- Actualizar las rutas por defecto porque la ubicación base de los archivos EXCZ y la carpeta SIIGO cambió de `D:\SIIWI01` a `D:\SIIWIS\SIIWI01` en el entorno Windows utilizado por las herramientas. 
- Sincronizar valores por defecto, scripts y documentación para evitar confusiones operativas y asegurar que los `.bat` y la CLI apunten a la ruta real esperada.

### Description
- Cambiados los valores por defecto y derivaciones de `EXCZDIR` y `SIIGO_BASE` en la configuración de la aplicación en `rentabilidad/config.py` y en el loader en `hojas/hoja01_loader.py` para usar `D:\SIIWIS\SIIWI01`/`D:\SIIWIS\SIIWI01\LISTADOS` en vez de la ruta anterior. 
- Actualizada la CLI y los defaults en `servicios/generar_listado_productos.py` para reflejar el nuevo ejemplo de `--siigo-base` y la derivación de `SIIGO_LOG`. 
- Sincronizados los scripts Windows: `todo_en_un_click.bat`, `GenerarListadoProductos.bat` y `Productos.bat` para usar la nueva ruta base y log por defecto. 
- Documentación y tests actualizados: `README.md` refleja la nueva carpeta por defecto y `tests/test_product_listing_service.py` actualiza los valores de prueba (`base_path` y `log_path`) para mantener consistencia con la nueva ruta; no se modificó la lógica de negocio. 

### Testing
- Ejecutado `pytest -q tests/test_product_listing_service.py` contra la suite local y el resultado fue `13 passed` (todas las pruebas exitosas). 
- No se introdujeron cambios funcionales en las clases o algoritmos, sólo valores por defecto, por lo que las pruebas existentes validan que el comportamiento permanece intacto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145104aa308323a3f48d6adb2323e0)