### PR TITLE
Centralize SIIGO path defaults and set default base to Z:\SIIWI01

### DIFF
--- a/GenerarListadoProductos.bat
+++ b/GenerarListadoProductos.bat
@@ -9,7 +9,7 @@ if exist "%PROJ_DIR%.env" (
 )
 
 if not defined SIIGO_DIR set "SIIGO_DIR=C:\Siigo"
-if not defined SIIGO_BASE set "SIIGO_BASE=D:\SIIWI01"
+if not defined SIIGO_BASE set "SIIGO_BASE=Z:\SIIWI01"
 if not defined PRODUCTOS_DIR set "PRODUCTOS_DIR=C:\Rentabilidad\Productos"
 if not defined SIIGO_LOG set "SIIGO_LOG=%SIIGO_BASE%\LOGS\log_catalogos.txt"
 

--- a/Productos.bat
+++ b/Productos.bat
@@ -15,7 +15,7 @@ for /f %%c in ('powershell -command "(Get-Date).ToString('dd')"') do set DIA=%%c
 cd /d C:\Siigo
 
 :: ===================== PRODUCTOS ============================
-ExcelSIIGO D:\SIIWI01\ %ANO% GETINV L JUAN 0110 D:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
+ExcelSIIGO Z:\SIIWI01\ %ANO% GETINV L JUAN 0110 Z:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
 echo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ de productos se guardan en la carpeta `Productos`.
 ### 2. Carga de EXCZ
 
 - Script principal: `hojas/hoja01_loader.py`.
-- Origen de datos: busca en `D:\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
+- Origen de datos: busca en `Z:\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
 - Acciones: importa el EXCZ en la Hoja 1, aplica las fórmulas necesarias y actualiza las hojas `CCOSTO` y `COD` con la misma fecha.
 
 ### 2.1 Fuente SQL Server (opcional)
@@ -105,7 +105,7 @@ python hojas/hoja01_loader.py --excel "C:\\Rentabilidad\\Informes\\Marzo\\Marzo 
   pip install -r requirements.txt
   ```
 - Archivo `PLANTILLA.xlsx` ubicado en `C:\\Rentabilidad\\`.
-- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
+- Carpeta con los archivos EXCZ, por defecto `Z:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
 
 ## Instalación
 
@@ -167,11 +167,11 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
   - `SIIGO_DIR`: carpeta donde está instalado SIIGO (por defecto `C:\\Siigo`).
   - `SIIGO_COMMAND`: nombre del ejecutable de SIIGO (por defecto `ExcelSIIGO`).
   - `SIIGO_BASE`: ruta base pasada como primer parámetro a `ExcelSIIGO`
-    (por defecto `D:\\SIIWI01`).
+    (por defecto `Z:\\SIIWI01`).
   - `PRODUCTOS_DIR`: carpeta destino de los Excel generados
     (por defecto `C:\\Rentabilidad\\Productos`).
   - `SIIGO_LOG`: ruta del archivo de log usado por `ExcelSIIGO`
-    (por defecto `D:\\SIIWI01\\LOGS\\log_catalogos.txt`).
+    (por defecto `Z:\\SIIWI01\\LOGS\\log_catalogos.txt`).
   - `SIIGO_WAIT_TIMEOUT`: tiempo máximo para esperar a que se cree el archivo
     de SIIGO (por defecto `60`).
   - `SIIGO_WAIT_INTERVAL`: intervalo entre verificaciones del archivo generado

--- a/hojas/hoja01_loader.py
+++ b/hojas/hoja01_loader.py
@@ -30,6 +30,7 @@ from rentabilidad.core.dates import DateResolver, YesterdayStrategy
 from rentabilidad.core.env import load_env
 from rentabilidad.core.excz import ExczFileFinder, ExczMetadata
 from rentabilidad.core.paths import PathContext, PathContextFactory, SPANISH_MONTHS
+from rentabilidad.core.siigo_paths import DEFAULT_EXCZ_DIR
 from rentabilidad.infra.sql_server import (
     SqlServerConfig,
     fetch_dataframe,
@@ -41,7 +42,7 @@ from rentabilidad.infra.sql_server import (
 load_env()
 PATH_CONTEXT: PathContext = PathContextFactory(os.environ).create()
 DEFAULT_RENT_DIR = os.environ.get("RENT_DIR", str(PATH_CONTEXT.base_dir))
-DEFAULT_EXCZDIR = os.environ.get("EXCZDIR", r"D:\\SIIWI01\\LISTADOS")
+DEFAULT_EXCZDIR = os.environ.get("EXCZDIR", DEFAULT_EXCZ_DIR)
 DEFAULT_EXCZ_PREFIX = os.environ.get("EXCZPREFIX", "EXCZ980")
 DEFAULT_CCOSTO_EXCZ_PREFIX = os.environ.get("CCOSTO_EXCZPREFIX", "EXCZ979")
 DEFAULT_COD_EXCZ_PREFIX = os.environ.get("COD_EXCZPREFIX", "EXCZ978")

--- a/rentabilidad/config.py
+++ b/rentabilidad/config.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 from rentabilidad.core.env import load_env
 from rentabilidad.core.paths import PathContext, PathContextFactory
+from rentabilidad.core.siigo_paths import (
+    DEFAULT_EXCZ_DIR,
+    DEFAULT_SIIGO_BASE,
+    build_siigo_log_path,
+)
 from rentabilidad.services.products import (
     ProductGenerationConfig,
     ProductListingService,
@@ -58,7 +63,7 @@ class Settings:
         self.ruta_plantilla: Path = self.context.template_path()
         self.plantilla_hoja: str | None = os.environ.get("PLANTILLA_HOJA")
 
-        self.excz_dir: Path = Path(os.environ.get("EXCZDIR", r"D:\\SIIWI01\\LISTADOS"))
+        self.excz_dir: Path = Path(os.environ.get("EXCZDIR", DEFAULT_EXCZ_DIR))
         self.excz_prefix: str = os.environ.get("EXCZPREFIX", "EXCZ980")
         self.excz_sheet: str = os.environ.get("EXCZ_SHEET", "Hoja1")
 
@@ -126,8 +131,10 @@ class Settings:
 
     def _build_product_config(self) -> ProductGenerationConfig:
         siigo_dir = Path(os.environ.get("SIIGO_DIR", r"C:\\Siigo"))
-        base_path = _ensure_trailing_backslash(os.environ.get("SIIGO_BASE", r"D:\\SIIWI01"))
-        log_path = os.environ.get("SIIGO_LOG", str(Path(base_path.rstrip("\\/")) / "LOGS" / "log_catalogos.txt"))
+        base_path = _ensure_trailing_backslash(
+            os.environ.get("SIIGO_BASE", DEFAULT_SIIGO_BASE)
+        )
+        log_path = os.environ.get("SIIGO_LOG", build_siigo_log_path(base_path))
 
         credenciales = SiigoCredentials(
             reporte=os.environ.get("SIIGO_REPORTE", "GETINV"),

--- a/rentabilidad/core/siigo_paths.py
+++ b/rentabilidad/core/siigo_paths.py
@@ -1,0 +1,29 @@
+"""Rutas por defecto compartidas para integraciones con SIIGO.
+
+Centralizar estos valores evita que los cambios de infraestructura queden
+replicados en varios módulos y mantiene los puntos de configuración alineados.
+"""
+
+from __future__ import annotations
+
+DEFAULT_SIIGO_BASE = r"Z:\SIIWI01"
+DEFAULT_EXCZ_DIR = rf"{DEFAULT_SIIGO_BASE}\LISTADOS"
+DEFAULT_SIIGO_LOG_FILENAME = "log_catalogos.txt"
+
+
+def build_siigo_log_path(base_path: str = DEFAULT_SIIGO_BASE) -> str:
+    """Construye la ruta Windows del log de ExcelSIIGO desde la base indicada."""
+
+    normalized_base = base_path.rstrip("\\/")
+    if not normalized_base:
+        return rf"LOGS\{DEFAULT_SIIGO_LOG_FILENAME}"
+
+    return rf"{normalized_base}\LOGS\{DEFAULT_SIIGO_LOG_FILENAME}"
+
+
+__all__ = [
+    "DEFAULT_EXCZ_DIR",
+    "DEFAULT_SIIGO_BASE",
+    "DEFAULT_SIIGO_LOG_FILENAME",
+    "build_siigo_log_path",
+]

--- a/servicios/generar_listado_productos.py
+++ b/servicios/generar_listado_productos.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from rentabilidad.core.env import load_env
 from rentabilidad.core.dates import DateResolver, TodayStrategy
 from rentabilidad.core.paths import PathContext, PathContextFactory
+from rentabilidad.core.siigo_paths import DEFAULT_SIIGO_BASE, build_siigo_log_path
 from rentabilidad.services.products import (
     ProductGenerationConfig,
     ProductListingService,
@@ -59,7 +60,7 @@ def build_parser(defaults: dict[str, str | float]) -> argparse.ArgumentParser:
     parser.add_argument(
         "--siigo-base",
         default=defaults["SIIGO_BASE"],
-        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. D:\\SIIWI01)",
+        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. Z:\\SIIWI01)",
     )
     parser.add_argument(
         "--productos-dir",
@@ -128,8 +129,11 @@ def _collect_defaults() -> dict[str, str | float]:
     context = PathContextFactory(os.environ).create()
     defaults = {
         "SIIGO_DIR": os.environ.get("SIIGO_DIR", r"C:\\Siigo"),
-        "SIIGO_BASE": os.environ.get("SIIGO_BASE", r"D:\\SIIWI01"),
-        "SIIGO_LOG": os.environ.get("SIIGO_LOG", str(Path(os.environ.get("SIIGO_BASE", r"D:\\SIIWI01")) / "LOGS" / "log_catalogos.txt")),
+        "SIIGO_BASE": os.environ.get("SIIGO_BASE", DEFAULT_SIIGO_BASE),
+        "SIIGO_LOG": os.environ.get(
+            "SIIGO_LOG",
+            build_siigo_log_path(os.environ.get("SIIGO_BASE", DEFAULT_SIIGO_BASE)),
+        ),
         "SIIGO_COMMAND": os.environ.get("SIIGO_COMMAND", "ExcelSIIGO"),
         "SIIGO_REPORTE": os.environ.get("SIIGO_REPORTE", "GETINV"),
         "SIIGO_EMPRESA": os.environ.get("SIIGO_EMPRESA", "L"),

--- a/tests/test_product_listing_service.py
+++ b/tests/test_product_listing_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from rentabilidad.core.paths import PathContext
+from rentabilidad.core.siigo_paths import DEFAULT_SIIGO_BASE, build_siigo_log_path
 from rentabilidad.config import _parse_required_files_env
 from rentabilidad.services.products import (
     ExcelSiigoFacade,
@@ -77,8 +78,8 @@ def _build_service(tmp_path: Path) -> ProductListingService:
 
     config = ProductGenerationConfig(
         siigo_dir=tmp_path,
-        base_path="D:\\SIIWI01\\",
-        log_path="D:\\SIIWI01\\LOGS\\log_catalogos.txt",
+        base_path=f"{DEFAULT_SIIGO_BASE}\\",
+        log_path=build_siigo_log_path(DEFAULT_SIIGO_BASE),
         credentials=credentials,
         activo_column=1,
         keep_columns=(1,),

--- a/todo_en_un_click.bat
+++ b/todo_en_un_click.bat
@@ -8,7 +8,7 @@ if exist "%PROJ_DIR%.env" (
 )
 if not defined RENT_DIR set "RENT_DIR=C:\Rentabilidad"
 if not defined TEMPLATE set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
-if not defined EXCZDIR set "EXCZDIR=D:\SIIWI01\LISTADOS"
+if not defined EXCZDIR set "EXCZDIR=Z:\SIIWI01\LISTADOS"
 
 where python >nul 2>nul || (
   echo ERROR: Python no esta en PATH. Instala Python y reintenta.


### PR DESCRIPTION
### Motivation
- Unify and centralize filesystem defaults used for SIIGO integrations to avoid repeated hardcoded paths and make it easier to change infrastructure paths in one place.
- Switch the default SIIGO base from `D:\SIIWI01` to `Z:\SIIWI01` across scripts and code to reflect the new environment layout.

### Description
- Add `rentabilidad/core/siigo_paths.py` exposing `DEFAULT_SIIGO_BASE`, `DEFAULT_EXCZ_DIR` and `build_siigo_log_path` to centralize SIIGO path logic. 
- Replace hardcoded `D:\SIIWI01`/`D:\SIIWI01\LISTADOS` occurrences with the new defaults and helpers in `servicios/generar_listado_productos.py`, `rentabilidad/config.py`, and `hojas/hoja01_loader.py`.
- Update Windows batch scripts `GenerarListadoProductos.bat`, `Productos.bat` and `todo_en_un_click.bat` to use `Z:\SIIWI01` (and updated EXCZDIR) as the default base/listados path.
- Update `README.md` to document the new default EXCZ folder (`Z:\SIIWI01\LISTADOS`) and the default SIIGO log path built from the centralized helper.
- Adjust tests in `tests/test_product_listing_service.py` to reference `DEFAULT_SIIGO_BASE` and `build_siigo_log_path` instead of hardcoded paths.

### Testing
- Ran the updated unit test file with `pytest tests/test_product_listing_service.py` and the test(s) executed successfully. 
- Ran the project's test suite with `pytest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145104aa308323a3f48d6adb2323e0)