### PR TITLE
Corrige ruta EXCZ por defecto a unidad Z

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Customize the paths below to match your environment.
 RENT_DIR=C:\Rentabilidad
 TEMPLATE=C:\Rentabilidad\PLANTILLA.xlsx
-EXCZDIR=D:\SIIWI01\LISTADOS
+EXCZDIR=Z:\SIIWI01\LISTADOS
 EXCZPREFIX=EXCZ980
 # Optional: point to an existing report if you only need to correr el loader
 #EXCEL=C:\Rentabilidad\INFORME_20240101.xlsx


### PR DESCRIPTION
### Motivation
- Corregir la ruta por defecto `EXCZDIR` que apuntaba a `D:\SIIWI01\LISTADOS` para que use `Z:\SIIWI01\LISTADOS`, que es la ubicación asumida por la documentación y otros módulos.

### Description
- Actualiza el fichero de configuración `.env` reemplazando `EXCZDIR=D:\SIIWI01\LISTADOS` por `EXCZDIR=Z:\SIIWI01\LISTADOS`.

### Testing
- Verificado que `settings.excz_dir` resuelve a `Z:\SIIWI01\LISTADOS` con `PYTHONDONTWRITEBYTECODE=1 python - <<'PY' ...` y comprobado con `rg` que no quedan referencias a `D:\SIIWI01` en el repositorio; ambas pruebas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b87ce92c83238e89c5c8abf92575)