### PR TITLE
Actualizar rutas SIIGO a unidad D

### DIFF
--- a/GenerarListadoProductos.bat
+++ b/GenerarListadoProductos.bat
@@ -9,7 +9,7 @@ if exist "%PROJ_DIR%.env" (
 )
 
 if not defined SIIGO_DIR set "SIIGO_DIR=C:\Siigo"
-if not defined SIIGO_BASE set "SIIGO_BASE=Z:\SIIWI01"
+if not defined SIIGO_BASE set "SIIGO_BASE=D:\SIIWI01"
 if not defined PRODUCTOS_DIR set "PRODUCTOS_DIR=C:\Rentabilidad\Productos"
 if not defined SIIGO_LOG set "SIIGO_LOG=%SIIGO_BASE%\LOGS\log_catalogos.txt"
 

--- a/Productos.bat
+++ b/Productos.bat
@@ -15,7 +15,7 @@ for /f %%c in ('powershell -command "(Get-Date).ToString('dd')"') do set DIA=%%c
 cd /d C:\Siigo
 
 :: ===================== PRODUCTOS ============================
-ExcelSIIGO Z:\SIIWI01\ %ANO% GETINV L JUAN 0110 Z:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
+ExcelSIIGO D:\SIIWI01\ %ANO% GETINV L JUAN 0110 D:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
 echo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ de productos se guardan en la carpeta `Productos`.
 ### 2. Carga de EXCZ
 
 - Script principal: `hojas/hoja01_loader.py`.
-- Origen de datos: busca en `Z:\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
+- Origen de datos: busca en `D:\SIIWI01\LISTADOS` el archivo `EXCZ***YYYYMMDDHHMMSS` cuya fecha coincida con la solicitada (por defecto el día anterior).
 - Acciones: importa el EXCZ en la Hoja 1, aplica las fórmulas necesarias y actualiza las hojas `CCOSTO` y `COD` con la misma fecha.
 
 ### 2.1 Fuente SQL Server (opcional)
@@ -105,7 +105,7 @@ python hojas/hoja01_loader.py --excel "C:\\Rentabilidad\\Informes\\Marzo\\Marzo 
   pip install -r requirements.txt
   ```
 - Archivo `PLANTILLA.xlsx` ubicado en `C:\\Rentabilidad\\`.
-- Carpeta con los archivos EXCZ, por defecto `Z:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
+- Carpeta con los archivos EXCZ, por defecto `D:\\SIIWI01\\LISTADOS\\`. Los nombres deben seguir el patrón `EXCZ***YYYYMMDDHHMMSS` para permitir la selección por fecha (prefijo configurable con `EXCZPREFIX` o `--excz-prefix`).
 
 ## Instalación
 
@@ -167,11 +167,11 @@ para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
   - `SIIGO_DIR`: carpeta donde está instalado SIIGO (por defecto `C:\\Siigo`).
   - `SIIGO_COMMAND`: nombre del ejecutable de SIIGO (por defecto `ExcelSIIGO`).
   - `SIIGO_BASE`: ruta base pasada como primer parámetro a `ExcelSIIGO`
-    (por defecto `Z:\\SIIWI01`).
+    (por defecto `D:\\SIIWI01`).
   - `PRODUCTOS_DIR`: carpeta destino de los Excel generados
     (por defecto `C:\\Rentabilidad\\Productos`).
   - `SIIGO_LOG`: ruta del archivo de log usado por `ExcelSIIGO`
-    (por defecto `Z:\\SIIWI01\\LOGS\\log_catalogos.txt`).
+    (por defecto `D:\\SIIWI01\\LOGS\\log_catalogos.txt`).
   - `SIIGO_WAIT_TIMEOUT`: tiempo máximo para esperar a que se cree el archivo
     de SIIGO (por defecto `60`).
   - `SIIGO_WAIT_INTERVAL`: intervalo entre verificaciones del archivo generado

--- a/rentabilidad/core/siigo_paths.py
+++ b/rentabilidad/core/siigo_paths.py
@@ -6,7 +6,7 @@ replicados en varios módulos y mantiene los puntos de configuración alineados.
 
 from __future__ import annotations
 
-DEFAULT_SIIGO_BASE = r"Z:\SIIWI01"
+DEFAULT_SIIGO_BASE = r"D:\SIIWI01"
 DEFAULT_EXCZ_DIR = rf"{DEFAULT_SIIGO_BASE}\LISTADOS"
 DEFAULT_SIIGO_LOG_FILENAME = "log_catalogos.txt"
 

--- a/servicios/generar_listado_productos.py
+++ b/servicios/generar_listado_productos.py
@@ -60,7 +60,7 @@ def build_parser(defaults: dict[str, str | float]) -> argparse.ArgumentParser:
     parser.add_argument(
         "--siigo-base",
         default=defaults["SIIGO_BASE"],
-        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. Z:\\SIIWI01)",
+        help="Ruta base usada como primer argumento para ExcelSIIGO (ej. D:\\SIIWI01)",
     )
     parser.add_argument(
         "--productos-dir",

--- a/todo_en_un_click.bat
+++ b/todo_en_un_click.bat
@@ -8,7 +8,7 @@ if exist "%PROJ_DIR%.env" (
 )
 if not defined RENT_DIR set "RENT_DIR=C:\Rentabilidad"
 if not defined TEMPLATE set "TEMPLATE=%RENT_DIR%\PLANTILLA.xlsx"
-if not defined EXCZDIR set "EXCZDIR=Z:\SIIWI01\LISTADOS"
+if not defined EXCZDIR set "EXCZDIR=D:\SIIWI01\LISTADOS"
 
 where python >nul 2>nul || (
   echo ERROR: Python no esta en PATH. Instala Python y reintenta.


### PR DESCRIPTION
### Motivation
- La infraestructura cambió la unidad donde se almacenan los archivos de SIIGO/EXCZ de `Z:` a `D:`, por lo que los valores por defecto y documentación deben reflejar la nueva ubicación.

### Description
- Cambia el valor por defecto `DEFAULT_SIIGO_BASE` de `rentabilidad/core/siigo_paths.py` de `Z:\SIIWI01` a `D:\SIIWI01`.
- Actualiza los scripts batch que usan la ruta SIIGO (`GenerarListadoProductos.bat`, `Productos.bat`, `todo_en_un_click.bat`) para apuntar a la unidad `D:` por defecto.
- Sincroniza la ayuda del CLI en `servicios/generar_listado_productos.py` y el `README.md` para mostrar `D:\SIIWI01` como ruta de ejemplo por defecto.
- No se cambiaron lógicas de negocio ni comportamiento de funciones, solo valores de ruta por defecto y mensajes/documentación.

### Testing
- Ejecuté `pytest -q` y los tests automatizados completaron con `57 passed in 4.83s`.
- No se agregaron ni modificaron tests unitarios en este cambio y las pruebas existentes pasaron sin fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47c3c387b883239f21a142622f2152)