### PR TITLE
Parametrizar rutas en `Productos.bat` y `.env`

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,9 @@
 # Customize the paths below to match your environment.
 RENT_DIR=C:\Rentabilidad
 TEMPLATE=C:\Rentabilidad\PLANTILLA.xlsx
-EXCZDIR=Z:\SIIWI01\LISTADOS
+EXCZDIR=D:\SIIWI01\LISTADOS
 EXCZPREFIX=EXCZ980
 # Optional: point to an existing report if you only need to correr el loader
 #EXCEL=C:\Rentabilidad\INFORME_20240101.xlsx
+
+SIIGO_BASE=D:\SIIWI01

--- a/Productos.bat
+++ b/Productos.bat
@@ -1,21 +1,50 @@
 @echo off
+setlocal
 :: ------------------------------------------------
-:: Script: Actualización de productos para la Rentabilidad
-:: Año: 2025
-:: Carpeta destino: D:\Rentabilidad\Productos
-:: Log: log_catalogos.txt
-:: Autor: Juan José Ortiz
+:: Script: Actualizacion de productos para Rentabilidad
+:: Las rutas se cargan desde .env o variables de entorno para evitar
+:: dependencias rigidas a unidades locales (D:, Z:, etc.).
 :: ------------------------------------------------
 
-:: Obtener el año actual
-for /f %%a in ('powershell -command "(Get-Date).ToString('yyyy')"') do set ANO=%%a
-for /f %%b in ('powershell -command "(Get-Date).ToString('MM')"') do set MES=%%b
-for /f %%c in ('powershell -command "(Get-Date).ToString('dd')"') do set DIA=%%c
+set "PROJ_DIR=%~dp0"
 
-cd /d C:\Siigo
+if exist "%PROJ_DIR%.env" (
+  for /f "usebackq tokens=1* delims==" %%a in ("%PROJ_DIR%.env") do (
+    if not "%%a"=="" set "%%a=%%b"
+  )
+)
+
+if not defined SIIGO_DIR set "SIIGO_DIR=C:\Siigo"
+if not defined SIIGO_BASE set "SIIGO_BASE=D:\SIIWI01"
+if not defined PRODUCTOS_DIR set "PRODUCTOS_DIR=C:\Rentabilidad\Productos"
+if not defined SIIGO_LOG set "SIIGO_LOG=%SIIGO_BASE%\LOGS\log_catalogos.txt"
+if not defined SIIGO_COMMAND set "SIIGO_COMMAND=ExcelSIIGO"
+if not defined SIIGO_REPORTE set "SIIGO_REPORTE=GETINV"
+if not defined SIIGO_EMPRESA set "SIIGO_EMPRESA=L"
+if not defined SIIGO_USUARIO set "SIIGO_USUARIO=JUAN"
+if not defined SIIGO_CLAVE set "SIIGO_CLAVE=0110"
+if not defined SIIGO_ESTADO_PARAM set "SIIGO_ESTADO_PARAM=S"
+if not defined SIIGO_RANGO_INI set "SIIGO_RANGO_INI=0010001000001"
+if not defined SIIGO_RANGO_FIN set "SIIGO_RANGO_FIN=0400027999999"
+
+for /f %%a in ('powershell -NoProfile -Command "(Get-Date).ToString('yyyy')"') do set "ANO=%%a"
+for /f %%b in ('powershell -NoProfile -Command "(Get-Date).ToString('MM')"') do set "MES=%%b"
+for /f %%c in ('powershell -NoProfile -Command "(Get-Date).ToString('dd')"') do set "DIA=%%c"
+
+if not exist "%SIIGO_DIR%" (
+  echo ERROR: No existe la carpeta de SIIGO "%SIIGO_DIR%". Ajusta SIIGO_DIR en .env o en el entorno.
+  pause
+  exit /b 2
+)
+
+if not exist "%PRODUCTOS_DIR%" mkdir "%PRODUCTOS_DIR%"
+
+cd /d "%SIIGO_DIR%"
 
 :: ===================== PRODUCTOS ============================
-ExcelSIIGO D:\SIIWI01\ %ANO% GETINV L JUAN 0110 D:\SIIWI01\LOGS\log_catalogos.txt S 0010001000001 0400027999999 C:\Rentabilidad\Productos\Productos%MES%%DIA%.xlsx
+"%SIIGO_COMMAND%" "%SIIGO_BASE%\" %ANO% %SIIGO_REPORTE% %SIIGO_EMPRESA% %SIIGO_USUARIO% %SIIGO_CLAVE% "%SIIGO_LOG%" %SIIGO_ESTADO_PARAM% %SIIGO_RANGO_INI% %SIIGO_RANGO_FIN% "%PRODUCTOS_DIR%\Productos%MES%%DIA%.xlsx"
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
-echo
+echo.
+echo OK: Productos actualizados en "%PRODUCTOS_DIR%\Productos%MES%%DIA%.xlsx"
+endlocal


### PR DESCRIPTION
### Motivation
- Corregir el error de búsqueda de `Z:\SIIWI01\LISTADOS` y eliminar dependencias a unidades rígidas que provocan fallos cuando la ruta no existe.
- Hacer que el script de productos acepte valores desde `.env` o variables de entorno para facilitar la configuración en distintos entornos.

### Description
- Cambié `EXCZDIR` en `.env` de `Z:\SIIWI01\LISTADOS` a `D:\SIIWI01\LISTADOS` y añadí `SIIGO_BASE=D:\SIIWI01` para alinear valores por defecto.
- Reescribí `Productos.bat` para cargar variables desde `.env` (si existe) o usar valores por defecto y añadí `setlocal`/`endlocal` para aislar el entorno.
- Añadí validaciones y mensajes claros cuando `SIIGO_DIR` no existe, y ahora se crea la carpeta de salida `PRODUCTOS_DIR` si falta.
- Reemplacé la invocación rígida de `ExcelSIIGO` por una construcción que usa `SIIGO_COMMAND`, `SIIGO_BASE`, `SIIGO_LOG`, credenciales parametrizadas y `PRODUCTOS_DIR` para la ruta de salida.

### Testing
- Ejecuté los tests automatizados con `python -m pytest` y todos los tests pasaron: `57 passed in 5.24s`.
- Se verificó que no quedan errores de formato básico con una comprobación local (no se reportaron fallos automáticos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47c97105348323ba0c33f346792a6e)