### PR TITLE
Use application service for product generation; enforce ACTIVO=='S' and update GUI/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,11 @@ encabezado con el logotipo de la empresa y el título del panel.
 
 `servicios/generar_listado_productos.py` ejecuta el comando `ExcelSIIGO`
 para generar un Excel de productos en `C:\\Rentabilidad\\Productos`
-(carpeta configurable) y luego deja únicamente las columnas **D**, **G** a
-**R** y **AX**, filtrando además los productos cuyo campo `ACTIVO`
-(columna AX) sea `S`. El nombre resultante sigue el formato
+(carpeta configurable) y luego deja únicamente las columnas **DESCRIPCIÓN**, **PRECIO 1** a
+**PRECIO 12** y **ACTIVO** (equivalentes a **D**, **G** a **R** y
+**AX** en el archivo original de SIIGO), filtrando además para conservar
+solo las filas cuyo campo `ACTIVO` sea exactamente `S` después de normalizar
+mayúsculas y espacios. El nombre resultante sigue el formato
 `productosMMDD.xlsx` y, por defecto, utiliza la fecha actual.
 
 - Ejecución rápida desde Windows:

--- a/rentabilidad/app/use_cases/ejecutar_productos_script.py
+++ b/rentabilidad/app/use_cases/ejecutar_productos_script.py
@@ -1,69 +1,35 @@
-"""Ejecución del script de productos desde la interfaz gráfica."""
+"""Generación del listado de productos desde la interfaz gráfica.
+
+Este caso de uso no ejecuta un ``.bat`` directamente. Delega en el servicio de
+aplicación para mantener la lógica de generación, espera, validación y limpieza
+en un único flujo reutilizable por CLI y GUI.
+"""
 
 from __future__ import annotations
 
-import os
-import subprocess
+from pathlib import Path
+
+from rentabilidad.core.dates import DateResolver, TodayStrategy
 
 from ..dto import GenerarInformeResponse
 from ...config import settings
 
 
-def _emit_lines(raw_output: str, channel: str, bus) -> None:
-    for raw in raw_output.splitlines():
-        text = raw.strip()
-        if text:
-            bus.publish(channel, text)
-
-
 def run(bus) -> GenerarInformeResponse:
-    if os.name != "nt":
-        mensaje = "La generación de productos solo está disponible en Windows."
-        bus.publish("error", mensaje)
-        return GenerarInformeResponse(ok=False, mensaje=mensaje)
-
-    script_path = settings.productos_batch_script
-    if script_path is None:
-        mensaje = "No se configuró el script Productos.bat a ejecutar."
-        bus.publish("error", mensaje)
-        return GenerarInformeResponse(ok=False, mensaje=mensaje)
-
-    if not script_path.exists():
-        mensaje = f"No se encontró el script de productos: {script_path}"
-        bus.publish("error", mensaje)
-        return GenerarInformeResponse(ok=False, mensaje=mensaje)
-
-    bus.publish("log", f"Ejecutando script de productos: {script_path}")
-
-    command = [os.environ.get("COMSPEC", "cmd.exe"), "/c", str(script_path)]
+    """Genera el listado de productos y publica eventos para la GUI."""
 
     try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=str(script_path.parent),
-        )
-    except FileNotFoundError as exc:  # pragma: no cover - dependiente del sistema
-        mensaje = f"No se pudo iniciar el intérprete de comandos: {exc}"
-        bus.publish("error", mensaje)
-        return GenerarInformeResponse(ok=False, mensaje=mensaje)
-    except Exception as exc:  # pragma: no cover - defensivo
-        mensaje = f"Error al ejecutar el script de productos: {exc}"
+        resolver = DateResolver(TodayStrategy())
+        objetivo = resolver.resolve(None)
+        bus.publish("log", f"Generando listado de productos para {objetivo:%Y-%m-%d}")
+
+        service = settings.build_product_service()
+        ruta: Path = service.generate(objetivo)
+    except Exception as exc:  # pragma: no cover - depende de SIIGO/Windows/archivos externos
+        mensaje = f"No se pudo generar el listado de productos: {exc}"
         bus.publish("error", mensaje)
         return GenerarInformeResponse(ok=False, mensaje=mensaje)
 
-    if result.stdout:
-        _emit_lines(result.stdout, "log", bus)
-    if result.stderr:
-        _emit_lines(result.stderr, "error", bus)
-
-    if result.returncode != 0:
-        mensaje = f"El script finalizó con código {result.returncode}"
-        bus.publish("error", mensaje)
-        return GenerarInformeResponse(ok=False, mensaje=mensaje)
-
-    bus.publish("done", "Productos generados correctamente")
-    return GenerarInformeResponse(ok=True, mensaje="OK")
-
+    mensaje = f"Listado de productos generado: {ruta}"
+    bus.publish("done", mensaje)
+    return GenerarInformeResponse(ok=True, mensaje=mensaje, ruta_salida=str(ruta))

--- a/rentabilidad/gui/app.py
+++ b/rentabilidad/gui/app.py
@@ -1448,7 +1448,7 @@ def build_ui() -> None:
                             with ui.column().classes("gap-1"):
                                 ui.label("Generar productos").classes("section-title")
                                 ui.label(
-                                    "Ejecuta el script Productos.bat para actualizar el listado de productos actual."
+                                    "Genera, valida y depura el listado de productos actual."
                                 ).classes("action-note")
 
                         productos_script = settings.productos_batch_script
@@ -1458,7 +1458,7 @@ def build_ui() -> None:
                             else "No configurado"
                         )
                         script_label = ui.label(
-                            f"Script configurado: {script_text}"
+                            f"Flujo configurado: {script_text}"
                         ).classes("action-note")
                         if productos_script:
                             with script_label:
@@ -1469,7 +1469,7 @@ def build_ui() -> None:
                                 "running", "Generando listado de productos…"
                             )
                             agregar_log(
-                                "Iniciando generación del listado de productos (Productos.bat).",
+                                "Iniciando generación del listado de productos.",
                                 "info",
                             )
                             try:
@@ -1495,7 +1495,7 @@ def build_ui() -> None:
                         if not productos_script:
                             btn_productos.disable()
                             ui.label(
-                                "Configura la ruta del script Productos.bat antes de ejecutar esta acción."
+                                "Configura SIIGO y la carpeta de productos antes de ejecutar esta acción."
                             ).classes("action-note text-amber-600")
 
                 with ui.card().classes("panel-card flex-1 min-w-[280px]"):

--- a/rentabilidad/gui/web.py
+++ b/rentabilidad/gui/web.py
@@ -343,7 +343,7 @@ def setup_ui() -> None:
     def ejecutar_productos() -> None:
         actualizar_estado("running", "Generando listado de productos…")
         agregar_log(
-            "Iniciando generación del listado de productos (Productos.bat)."
+            "Iniciando generación del listado de productos."
         )
         uc_productos(bus)
 
@@ -474,13 +474,13 @@ def setup_ui() -> None:
                     ui.icon("inventory_2").classes("text-violet-500")
                     ui.label("Generar productos").classes("font-medium")
                 ui.label(
-                    "Ejecuta el script Productos.bat para actualizar el listado de productos."
+                    "Genera, valida y depura el listado de productos configurado."
                 ).classes("px-5 pb-3 text-sm text-gray-500 leading-snug")
                 productos_script = settings.productos_batch_script
                 script_text = (
                     _shorten(productos_script) if productos_script else "No configurado"
                 )
-                script_label = ui.label(f"Script: {script_text}")
+                script_label = ui.label(f"Flujo configurado: {script_text}")
                 script_label.classes("px-5 pb-3 text-xs text-gray-400")
                 if productos_script:
                     with script_label:
@@ -493,7 +493,7 @@ def setup_ui() -> None:
                 if not productos_script:
                     btn_productos.disable()
                     ui.label(
-                        "Configura la ruta del script Productos.bat antes de ejecutar esta acción."
+                        "Configura SIIGO y la carpeta de productos antes de ejecutar esta acción."
                     ).classes("px-5 pb-5 text-xs text-amber-500")
                 else:
                     ui.label(

--- a/rentabilidad/services/products.py
+++ b/rentabilidad/services/products.py
@@ -234,8 +234,12 @@ def resolve_column_index(value: int | str) -> int:
 class WorkbookCleaner:
     """Responsable de filtrar columnas y filas en el archivo generado."""
 
-    #: Número de filas iniciales que deben preservarse sin modificaciones.
-    _RESERVED_HEADER_ROWS = 5
+    #: Número de filas de metadatos iniciales que deben preservarse sin modificaciones.
+    _RESERVED_METADATA_ROWS = 5
+    #: Fila donde ExcelSIIGO entrega los encabezados del catálogo.
+    _HEADER_ROW = _RESERVED_METADATA_ROWS + 1
+    #: Primera fila que contiene productos reales sujetos al filtro de ACTIVO.
+    _FIRST_PRODUCT_ROW = _HEADER_ROW + 1
 
     def __init__(self, activo_column: int | str, keep_columns: Iterable[int | str]):
         self._activo_idx = resolve_column_index(activo_column)
@@ -263,10 +267,9 @@ class WorkbookCleaner:
             )
 
         removed_rows = 0
-        first_data_row = self._RESERVED_HEADER_ROWS + 1
-        for row in range(ws.max_row, first_data_row - 1, -1):
+        for row in range(ws.max_row, self._FIRST_PRODUCT_ROW - 1, -1):
             value = ws.cell(row=row, column=self._activo_idx).value
-            if self._normalize(value) == "N":
+            if self._normalize(value) != "S":
                 ws.delete_rows(row, 1)
                 removed_rows += 1
 
@@ -300,10 +303,10 @@ class WorkbookCleaner:
                 "La hoja activa no tiene la columna requerida para estado del producto."
             )
 
-        header_rows = dataframe.iloc[: self._RESERVED_HEADER_ROWS]
-        data_rows = dataframe.iloc[self._RESERVED_HEADER_ROWS :].copy()
+        header_rows = dataframe.iloc[: self._HEADER_ROW]
+        data_rows = dataframe.iloc[self._HEADER_ROW :].copy()
 
-        activos_mask = data_rows.iloc[:, activo_idx_zero].apply(self._normalize) != "N"
+        activos_mask = data_rows.iloc[:, activo_idx_zero].apply(self._normalize) == "S"
         filtered_rows = data_rows[activos_mask]
         removed_rows = len(data_rows) - len(filtered_rows)
 

--- a/tests/test_ejecutar_productos_use_case.py
+++ b/tests/test_ejecutar_productos_use_case.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from rentabilidad.app.use_cases import ejecutar_productos_script as use_case
+
+
+class _Bus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def publish(self, channel: str, message: str) -> None:
+        self.events.append((channel, message))
+
+
+class _Service:
+    def __init__(self, result: Path | Exception) -> None:
+        self.result = result
+        self.calls: list[date] = []
+
+    def generate(self, target_date: date) -> Path:
+        self.calls.append(target_date)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class _Settings:
+    def __init__(self, service: _Service) -> None:
+        self.service = service
+
+    def build_product_service(self) -> _Service:
+        return self.service
+
+
+def test_run_generates_products_through_application_service(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "productos0708.xlsx"
+    service = _Service(target)
+    bus = _Bus()
+
+    class _FixedStrategy:
+        def default(self) -> date:
+            return date(2026, 7, 8)
+
+    monkeypatch.setattr(use_case, "TodayStrategy", _FixedStrategy)
+    monkeypatch.setattr(use_case, "settings", _Settings(service))
+
+    response = use_case.run(bus)
+
+    assert response.ok is True
+    assert response.ruta_salida == str(target)
+    assert service.calls == [date(2026, 7, 8)]
+    assert ("done", f"Listado de productos generado: {target}") in bus.events
+
+
+def test_run_reports_service_errors(monkeypatch) -> None:
+    service = _Service(RuntimeError("SIIGO no generó el archivo esperado"))
+    bus = _Bus()
+
+    monkeypatch.setattr(use_case, "settings", _Settings(service))
+
+    response = use_case.run(bus)
+
+    assert response.ok is False
+    assert "SIIGO no generó el archivo esperado" in response.mensaje
+    assert any(channel == "error" for channel, _ in bus.events)

--- a/tests/test_workbook_cleaner.py
+++ b/tests/test_workbook_cleaner.py
@@ -70,6 +70,42 @@ def test_workbook_cleaner_acepta_columna_activo_numerica(tmp_path) -> None:
     libro.close()
 
 
+def test_workbook_cleaner_deja_solo_productos_con_activo_s(tmp_path) -> None:
+    destino = tmp_path / "productos.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    for idx in range(1, 6):
+        ws.append([f"Meta {idx}", None, None, None, None])
+    ws.append(["COD", "DESCRIPCIÓN", "ACTIVO", "PRECIO", "OTRA"])
+    ws.append(["P-1", "Producto activo", "S", 120.0, "IGNORAR"])
+    ws.append(["P-2", "Producto activo con espacios", " s ", 121.0, "IGNORAR"])
+    ws.append(["P-3", "Producto inactivo", "N", 30.0, "IGNORAR"])
+    ws.append(["P-4", "Producto sin estado", None, 40.0, "IGNORAR"])
+    ws.append(["P-5", "Producto con otro estado", "A", 50.0, "IGNORAR"])
+    wb.save(destino)
+    wb.close()
+
+    cleaner = WorkbookCleaner(activo_column="C", keep_columns=["B", "D"])
+    resultado = cleaner.clean(destino)
+
+    libro = load_workbook(resultado)
+    hoja = libro.active
+
+    assert hoja.max_row == 8
+    assert [hoja.cell(6, col).value for col in range(1, 4)] == [
+        "DESCRIPCIÓN",
+        "ACTIVO",
+        "PRECIO",
+    ]
+    assert [hoja.cell(row, 1).value for row in range(7, 9)] == [
+        "Producto activo",
+        "Producto activo con espacios",
+    ]
+    assert [hoja.cell(row, 2).value for row in range(7, 9)] == ["S", " s "]
+
+    libro.close()
+
+
 def _crear_libro_xls(path: Path) -> None:
     xlwt = pytest.importorskip("xlwt")
 


### PR DESCRIPTION
### Motivation
- Evitar ejecutar un `.bat` desde la GUI y centralizar la generación de listados de productos en un servicio de aplicación reutilizable. 
- Asegurar que la limpieza del libro deje únicamente las filas con `ACTIVO == 'S'` tras normalizar, y documentar mejor las columnas conservadas. 

### Description
- Refactoriza el caso de uso `ejecutar_productos_script.run` para delegar en `settings.build_product_service().generate(...)` y usar `DateResolver(TodayStrategy())` en lugar de invocar un intérprete de comandos. 
- Cambia mensajes y etiquetas en la GUI (`rentabilidad/gui/app.py` y `rentabilidad/gui/web.py`) para hablar de "flujo configurado" y no mencionar `Productos.bat`. 
- Ajusta `WorkbookCleaner` en `rentabilidad/services/products.py` renombrando constantes de filas, definiendo `_HEADER_ROW` y `_FIRST_PRODUCT_ROW`, y cambia la lógica para conservar solo las filas cuyo `ACTIVO` normalizado sea exactamente `S` tanto en la ruta de `openpyxl` como en la de legado con `pandas`. 
- Actualiza la documentación en `README.md` para describir las columnas mantenidas y la normalización del campo `ACTIVO`. 
- Añade pruebas unitarias en `tests/test_ejecutar_productos_use_case.py` y extiende `tests/test_workbook_cleaner.py` para cubrir el nuevo comportamiento de filtrado. 

### Testing
- Ejecuté las nuevas pruebas unitarias `tests/test_ejecutar_productos_use_case.py` y `tests/test_workbook_cleaner.py` bajo `pytest` y verificaron que el caso de uso publica eventos `done`/`error` y que `WorkbookCleaner` deja solo productos con `ACTIVO == 'S'`. 
- Todas las pruebas automáticas relacionadas con los cambios pasaron correctamente con `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e60d80b588323aa6917cfa4887588)